### PR TITLE
Cancel requests

### DIFF
--- a/example/PaymentPage/1-example-initialize.php
+++ b/example/PaymentPage/1-example-initialize.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/../credentials.php';
 
 // Step 1:
 // Initialize the payment page
-// See https://test.saferpay.com/jsonapihelp/#Payment_v1_PaymentPage_Initialize
+// See https://saferpay.github.io/jsonapi/#Payment_v1_PaymentPage_Initialize
 
 $requestHeader = (new Container\RequestHeader())
     ->setCustomerId($customerId)
@@ -68,7 +68,7 @@ echo 'Redirect to: ' . $response->getRedirectUrl() ."<br>\n";
 
 // Step 5:
 // Fill in test payment page. For dummy credit card numbers see
-// https://www.six-payment-services.com/de/site/saferpay-support/testaccount/Saferpay_Testdaten.html
+// https://saferpay.github.io/sndbx/paymentmeans.html
 
 // Step 6:
 // On success page and notification url, assert the payment has been successful.

--- a/example/SecureAliasStore/1-example-insert.php
+++ b/example/SecureAliasStore/1-example-insert.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/../credentials.php';
 
 // Step 1:
 // Prepare the assert request
-// See http://saferpay.github.io/jsonapi/#Payment_v1_Alias_Insert
+// See https://saferpay.github.io/jsonapi/#Payment_v1_Alias_Insert
 
 $requestHeader = (new Container\RequestHeader())
     ->setCustomerId($customerId)
@@ -44,7 +44,7 @@ echo 'Redirect to: ' . $response->getRedirectUrl() ."<br>\n";
 
 // Step 5:
 // Fill in test payment page. For dummy credit card numbers see
-// https://www.six-payment-services.com/de/site/saferpay-support/testaccount/Saferpay_Testdaten.html
+// https://saferpay.github.io/sndbx/paymentmeans.html
 
 // Step 6:
 // On success page, assert the data has successfully been inserted

--- a/example/SecureAliasStore/2-example-assert.php
+++ b/example/SecureAliasStore/2-example-assert.php
@@ -13,7 +13,7 @@ $token = 'xxx';
 
 // Step 1:
 // Prepare the assert request
-// See http://saferpay.github.io/jsonapi/#Payment_v1_Alias_AssertInsert
+// See https://saferpay.github.io/jsonapi/#Payment_v1_Alias_AssertInsert
 
 $requestHeader = (new Container\RequestHeader())
     ->setCustomerId($customerId)

--- a/example/SecureAliasStore/3-example-insert-direct.php
+++ b/example/SecureAliasStore/3-example-insert-direct.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/../credentials.php';
 
 // Step 1:
 // Prepare the insert direct request
-// See http://saferpay.github.io/jsonapi/#Payment_v1_Alias_InsertDirect
+// See https://saferpay.github.io/jsonapi/#Payment_v1_Alias_InsertDirect
 
 $requestHeader = (new Container\RequestHeader())
     ->setCustomerId($customerId)

--- a/example/SecureAliasStore/4-example-delete.php
+++ b/example/SecureAliasStore/4-example-delete.php
@@ -13,7 +13,7 @@ $aliasId = 'xxx';
 
 // Step 1:
 // Prepare the delete request
-// http://saferpay.github.io/jsonapi/#Payment_v1_Alias_Delete
+// https://saferpay.github.io/jsonapi/#Payment_v1_Alias_Delete
 
 $requestHeader = (new Container\RequestHeader())
     ->setCustomerId($customerId)

--- a/example/Transaction/1-example-capture.php
+++ b/example/Transaction/1-example-capture.php
@@ -7,13 +7,13 @@ use \Ticketpark\SaferpayJson\Transaction\CaptureRequest;
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/../credentials.php';
 
-// A transactionid you received with a successful payment (see ../PaymentPage/2-example-assert.php)
+// A transactionid you received with a successful assert request (see ../PaymentPage/2-example-assert.php)
 
 $transactionId = 'xxx';
 
 // Step 1:
 // Prepare the capture request
-// https://test.saferpay.com/jsonapihelp/#Payment_v1_Transaction_Capture
+// https://saferpay.github.io/jsonapi/#Payment_v1_Transaction_Capture
 
 $requestHeader = (new Container\RequestHeader())
     ->setCustomerId($customerId)

--- a/example/Transaction/2-example-cancel.php
+++ b/example/Transaction/2-example-cancel.php
@@ -1,0 +1,37 @@
+<?php
+
+use \Ticketpark\SaferpayJson\Container;
+use \Ticketpark\SaferpayJson\Message\ErrorResponse;
+use \Ticketpark\SaferpayJson\Transaction\CancelRequest;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../credentials.php';
+
+// A transactionid you received with a successful assert request (see ../PaymentPage/2-example-assert.php)
+
+$transactionId = 'xxx';
+
+// Step 1:
+// Prepare the cancel request
+// https://saferpay.github.io/jsonapi/#Payment_v1_Transaction_Cancel
+
+$requestHeader = (new Container\RequestHeader())
+    ->setCustomerId($customerId)
+    ->setRequestId(uniqid());
+
+$transactionReference = (new Container\TransactionReference())
+    ->setTransactionId($transactionId);
+
+$response = (new CancelRequest($apiKey, $apiSecret))
+    ->setRequestHeader($requestHeader)
+    ->setTransactionReference($transactionReference)
+    ->execute();
+
+// Step 2:
+// Check for successful response
+
+if ($response instanceof ErrorResponse) {
+    die($response->getErrorMessage());
+}
+
+echo 'The transaction has successfully been canceled! Transaction-ID: ' . $response->getTransactionId();

--- a/lib/SaferpayJson/Transaction/CancelRequest.php
+++ b/lib/SaferpayJson/Transaction/CancelRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Ticketpark\SaferpayJson\Transaction;
+
+use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Message\Request;
+
+class CancelRequest extends Request
+{
+    const API_PATH = '/Payment/v1/Transaction/Cancel';
+
+    const RESPONSE_CLASS = 'Ticketpark\SaferpayJson\Transaction\CancelResponse';
+
+    /**
+     * @var Ticketpark\SaferpayJson\Container\TransactionReference
+     * @SerializedName("TransactionReference")
+     */
+    protected $transactionReference;
+
+    /**
+     * @return Ticketpark\SaferpayJson\Container\TransactionReference
+     */
+    public function getTransactionReference()
+    {
+        return $this->transactionReference;
+    }
+
+    /**
+     * @param Ticketpark\SaferpayJson\Container\TransactionReference $transactionReference
+     * @return CancelRequest
+     */
+    public function setTransactionReference($transactionReference)
+    {
+        $this->transactionReference = $transactionReference;
+
+        return $this;
+    }
+}

--- a/lib/SaferpayJson/Transaction/CancelResponse.php
+++ b/lib/SaferpayJson/Transaction/CancelResponse.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Ticketpark\SaferpayJson\Transaction;
+
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+use Ticketpark\SaferpayJson\Message\Response;
+
+class CancelResponse extends Response
+{
+    /**
+     * @var string
+     * @SerializedName("TransactionId")
+     * @Type("string")
+     */
+    protected $transactionId;
+
+    /**
+     * @var string
+     * @SerializedName("OrderId")
+     * @Type("string")
+     */
+    protected $orderId;
+
+    /**
+     * @var string
+     * @SerializedName("Date")
+     * @Type("string")
+     */
+    protected $date;
+
+    /**
+     * @return string
+     */
+    public function getTransactionId()
+    {
+        return $this->transactionId;
+    }
+
+    /**
+     * @param string $transactionId
+     * @return CancelResponse
+     */
+    public function setTransactionId($transactionId)
+    {
+        $this->transactionId = $transactionId;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrderId()
+    {
+        return $this->orderId;
+    }
+
+    /**
+     * @param string $orderId
+     * @return CancelResponse
+     */
+    public function setOrderId($orderId)
+    {
+        $this->orderId = $orderId;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @param string $date
+     * @return CancelResponse
+     */
+    public function setDate($date)
+    {
+        $this->date = $date;
+
+        return $this;
+    }
+}

--- a/tests/SaferpayJson/Tests/Transaction/CancelRequestTest.php
+++ b/tests/SaferpayJson/Tests/Transaction/CancelRequestTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Ticketpark\SaferpayJson\Tests\Transaction;
+
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use JMS\Serializer\SerializerBuilder;
+use Ticketpark\SaferpayJson\Transaction\CancelRequest;
+
+class CancelRequestTest extends \PHPUnit_Framework_TestCase
+{
+    public function testErrorResponse()
+    {
+        $initializer = new CancelRequest();
+        $initializer->setBrowser($this->getBrowserMock(false));
+        $response = $initializer->execute();
+
+        $this->assertInstanceOf('Ticketpark\SaferpayJson\Message\ErrorResponse', $response);
+    }
+
+    public function testSuccessfulResponse()
+    {
+        $initializer = new CancelRequest();
+        $initializer->setBrowser($this->getBrowserMock(true));
+        $response = $initializer->execute();
+
+        $this->assertInstanceOf('Ticketpark\SaferpayJson\Transaction\CancelResponse', $response);
+    }
+
+    public function getBrowserMock($successful)
+    {
+        $browser = $this->getMockBuilder('Buzz\Browser')
+            ->disableOriginalConstructor()
+            ->setMethods(array('post'))
+            ->getMock();
+
+        $browser->expects($this->once())
+            ->method('post')
+            ->will($this->returnValue($this->getResponseMock($successful)));
+
+        return $browser;
+    }
+
+    public function getResponseMock($successful)
+    {
+        $response = $this->getMockBuilder('Buzz\Message\Response')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getStatusCode', 'isClientError', 'getContent'))
+            ->getMock();
+
+        $response->expects($this->any())
+            ->method('isClientError')
+            ->will($this->returnValue(!$successful));
+
+        $response->expects($this->any())
+            ->method('getStatusCode')
+            ->will($this->returnValue(200));
+
+        if ($successful) {
+            $content = $this->getFakedApiResponse('Ticketpark\SaferpayJson\Transaction\CancelResponse');
+        } else {
+            $content = $this->getFakedApiResponse('Ticketpark\SaferpayJson\Message\ErrorResponse');
+        }
+
+        $response->expects($this->any())
+            ->method('getContent')
+            ->will($this->returnValue($content));
+
+        return $response;
+    }
+
+    public function getFakedApiResponse($class)
+    {
+        AnnotationRegistry::registerLoader('class_exists');
+        $serializer = SerializerBuilder::create()->build();
+
+        $response = new $class();
+
+        return $serializer->serialize($response, 'json');
+    }
+}


### PR DESCRIPTION
Transactions might need to be canceled in some scenarios (e.g. liability shift not granted). This PR adds the missing request and response objects. 