### PR TITLE
Add recurring payments support

### DIFF
--- a/example/RecurringPayment/1-example-recurring.php
+++ b/example/RecurringPayment/1-example-recurring.php
@@ -1,0 +1,42 @@
+<?php
+
+use Ticketpark\SaferpayJson\Container;
+use Ticketpark\SaferpayJson\Message\ErrorResponse;
+use Ticketpark\SaferpayJson\PaymentPage\AuthorizeReferencedRequest;
+use Ticketpark\SaferpayJson\PaymentPage\AuthorizeReferencedResponse;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../credentials.php';
+
+// ID of an existing captured transaction flagged as recurring. eg: $payment->setRecurring(new Recurring(true))
+$transactionId = '';
+
+$requestHeader = (new Container\RequestHeader())
+    ->setCustomerId($customerId)
+    ->setRequestId(uniqid());
+
+$amount = (new Container\Amount())
+    ->setCurrencyCode('CHF')
+    ->setValue(5000); // amount in cents
+
+$response = (new AuthorizeReferencedRequest($apiKey, $apiSecret, true))
+    ->setRequestHeader($requestHeader)
+    ->setPayment((new Container\Payment())->setAmount($amount))
+    ->setTransactionReference((new Container\TransactionReference())->setTransactionId($transactionId))
+    ->setTerminalId($terminalId)
+    ->execute();
+
+if ($response instanceof ErrorResponse) {
+    die($response->getErrorMessage());
+}
+
+/** @var AuthorizeReferencedResponse $response */
+echo sprintf("Transaction ID: %s, Status: %s, via %s (%s)",
+    $response->getTransaction()->getId(),
+    $response->getTransaction()->getStatus(),
+    $response->getPaymentMeans()->getBrand()->getName(),
+    $response->getPaymentMeans()->getDisplayText()
+);
+
+// Recurring payment transactions still need to be captured.
+// see: Transaction/1-example-catpure.php

--- a/lib/SaferpayJson/Container/Payment.php
+++ b/lib/SaferpayJson/Container/Payment.php
@@ -31,6 +31,12 @@ class Payment
     protected $payerNote;
 
     /**
+     * @var Recurring
+     * @SerializedName("Recurring")
+     */
+    protected $recurring;
+
+    /**
      * @return Ticketpark\SaferpayJson\Container\Amount
      */
     public function getAmount()
@@ -102,6 +108,25 @@ class Payment
     public function setPayerNote($payerNote)
     {
         $this->payerNote = $payerNote;
+
+        return $this;
+    }
+
+    /**
+     * @return Recurring
+     */
+    public function getRecurring()
+    {
+        return $this->recurring;
+    }
+
+    /**
+     * @param Recurring $recurring
+     * @return Payment
+     */
+    public function setRecurring($recurring)
+    {
+        $this->recurring = $recurring;
 
         return $this;
     }

--- a/lib/SaferpayJson/Container/Recurring.php
+++ b/lib/SaferpayJson/Container/Recurring.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Ticketpark\SaferpayJson\Container;
+
+use JMS\Serializer\Annotation\SerializedName;
+
+class Recurring
+{
+    /**
+     * @var bool
+     * @SerializedName("Initial")
+     */
+    protected $initial;
+
+    public function __construct($initial = true)
+    {
+        $this->initial = $initial;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isInitial()
+    {
+        return $this->initial;
+    }
+
+    /**
+     * @param bool $initial
+     */
+    public function setInitial($initial)
+    {
+        $this->initial = $initial;
+    }
+}

--- a/lib/SaferpayJson/PaymentPage/AuthorizeReferencedRequest.php
+++ b/lib/SaferpayJson/PaymentPage/AuthorizeReferencedRequest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Ticketpark\SaferpayJson\PaymentPage;
+
+use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Container\Payment;
+use Ticketpark\SaferpayJson\Container\TransactionReference;
+use Ticketpark\SaferpayJson\Message\Request;
+
+class AuthorizeReferencedRequest extends Request
+{
+    const API_PATH = '/Payment/v1/Transaction/AuthorizeReferenced';
+
+    const RESPONSE_CLASS = 'Ticketpark\SaferpayJson\PaymentPage\AuthorizeReferencedResponse';
+
+    /**
+     * @var string
+     * @SerializedName("TerminalId")
+     */
+    protected $terminalId;
+
+    /**
+     * @var Payment
+     * @SerializedName("Payment")
+     */
+    protected $payment;
+
+    /**
+     * @var TransactionReference
+     * @SerializedName("TransactionReference")
+     */
+    protected $transactionReference;
+
+    /**
+     * @return string
+     */
+    public function getTerminalId()
+    {
+        return $this->terminalId;
+    }
+
+    /**
+     * @param string $terminalId
+     * @return AuthorizeReferencedRequest
+     */
+    public function setTerminalId($terminalId)
+    {
+        $this->terminalId = $terminalId;
+
+        return $this;
+    }
+
+    /**
+     * @return TransactionReference
+     */
+    public function getTransactionReference()
+    {
+        return $this->transactionReference;
+    }
+
+    /**
+     * @param TransactionReference $transactionReference
+     * @return AuthorizeReferencedRequest
+     */
+    public function setTransactionReference($transactionReference)
+    {
+        $this->transactionReference = $transactionReference;
+
+        return $this;
+    }
+
+    /**
+     * @return Payment
+     */
+    public function getPayment()
+    {
+        return $this->payment;
+    }
+
+    /**
+     * @param Payment $payment
+     * @return AuthorizeReferencedRequest
+     */
+    public function setPayment($payment)
+    {
+        $this->payment = $payment;
+
+        return $this;
+    }
+}

--- a/lib/SaferpayJson/PaymentPage/AuthorizeReferencedResponse.php
+++ b/lib/SaferpayJson/PaymentPage/AuthorizeReferencedResponse.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Ticketpark\SaferpayJson\PaymentPage;
+
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+use Ticketpark\SaferpayJson\Container\PaymentMeans;
+use Ticketpark\SaferpayJson\Container\Transaction;
+use Ticketpark\SaferpayJson\Message\Response;
+
+class AuthorizeReferencedResponse extends Response
+{
+    /**
+     * @var Transaction
+     * @SerializedName("Transaction")
+     * @Type("Ticketpark\SaferpayJson\Container\Transaction")
+     */
+    protected $transaction;
+
+    /**
+     * @var PaymentMeans
+     * @SerializedName("PaymentMeans")
+     * @Type("Ticketpark\SaferpayJson\Container\PaymentMeans")
+     */
+    protected $paymentMeans;
+
+    /**
+     * @return Transaction
+     */
+    public function getTransaction()
+    {
+        return $this->transaction;
+    }
+
+    /**
+     * @param Transaction $transaction
+     */
+    public function setTransaction($transaction)
+    {
+        $this->transaction = $transaction;
+    }
+
+    /**
+     * @return PaymentMeans
+     */
+    public function getPaymentMeans()
+    {
+        return $this->paymentMeans;
+    }
+
+    /**
+     * @param PaymentMeans $paymentMeans
+     */
+    public function setPaymentMeans($paymentMeans)
+    {
+        $this->paymentMeans = $paymentMeans;
+    }
+}

--- a/tests/SaferpayJson/Tests/PaymentPage/AuthorizeReferencedRequestTest.php
+++ b/tests/SaferpayJson/Tests/PaymentPage/AuthorizeReferencedRequestTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Ticketpark\SaferpayJson\Tests\PaymentPage;
+
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use JMS\Serializer\SerializerBuilder;
+use Ticketpark\SaferpayJson\PaymentPage\AuthorizeReferencedRequest;
+
+class AuthorizeReferencedRequestTest extends \PHPUnit_Framework_TestCase
+{
+    public function testErrorResponse()
+    {
+        $initializer = new AuthorizeReferencedRequest();
+        $initializer->setBrowser($this->getBrowserMock(false));
+        $response = $initializer->execute();
+
+        $this->assertInstanceOf('Ticketpark\SaferpayJson\Message\ErrorResponse', $response);
+    }
+
+    public function testSuccessfulResponse()
+    {
+        $initializer = new AuthorizeReferencedRequest();
+        $initializer->setBrowser($this->getBrowserMock(true));
+        $response = $initializer->execute();
+
+        $this->assertInstanceOf('Ticketpark\SaferpayJson\PaymentPage\AuthorizeReferencedResponse', $response);
+    }
+
+    public function getBrowserMock($successful)
+    {
+        $browser = $this->getMockBuilder('Buzz\Browser')
+            ->disableOriginalConstructor()
+            ->setMethods(array('post'))
+            ->getMock();
+
+        $browser->expects($this->once())
+            ->method('post')
+            ->will($this->returnValue($this->getResponseMock($successful)));
+
+        return $browser;
+    }
+
+    public function getResponseMock($successful)
+    {
+        $response = $this->getMockBuilder('Buzz\Message\Response')
+            ->disableOriginalConstructor()
+            ->setMethods(array('getStatusCode', 'isClientError', 'getContent'))
+            ->getMock();
+
+        $response->expects($this->any())
+            ->method('isClientError')
+            ->will($this->returnValue(!$successful));
+
+        $response->expects($this->any())
+            ->method('getStatusCode')
+            ->will($this->returnValue(200));
+
+        if ($successful) {
+            $content = $this->getFakedApiResponse('Ticketpark\SaferpayJson\PaymentPage\AuthorizeReferencedResponse');
+        } else {
+            $content = $this->getFakedApiResponse('Ticketpark\SaferpayJson\Message\ErrorResponse');
+        }
+
+        $response->expects($this->any())
+            ->method('getContent')
+            ->will($this->returnValue($content));
+
+        return $response;
+    }
+
+    public function getFakedApiResponse($class)
+    {
+        AnnotationRegistry::registerLoader('class_exists');
+        $serializer = SerializerBuilder::create()->build();
+
+        $response = new $class();
+
+        return $serializer->serialize($response, 'json');
+    }
+}


### PR DESCRIPTION
Hi all, this PR implements recurring payments through the `Recurring{Initial=True}` flag on the initial payment and the request to the `AuthorizeReferenced` Payment API endpoint.

Implemented on behalf of @artack in Zurich.