### PR TITLE
Minor property updates to use the latest api version

### DIFF
--- a/lib/SaferpayJson/Container/ResponseHeader.php
+++ b/lib/SaferpayJson/Container/ResponseHeader.php
@@ -10,7 +10,7 @@ class ResponseHeader
     /**
      * @var string
      * @SerializedName("SpecVersion")
-     * @Type("double")
+     * @Type("string")
      */
     protected $specVersion = '1.2';
 

--- a/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
@@ -81,13 +81,13 @@ class InitializeRequest extends Request
 
     /**
      * @var RegisterAlias|null
-     * @Serializer\SerializedName("RegisterAlias")
+     * @SerializedName("RegisterAlias")
      */
     protected $registerAlias;
 
     /**
      * @var Styling|null
-     * @Serializer\SerializedName("Styling")
+     * @SerializedName("Styling")
      */
     protected $styling;
 

--- a/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
@@ -6,7 +6,9 @@ use JMS\Serializer\Annotation\SerializedName;
 use Ticketpark\SaferpayJson\Container\Notification;
 use Ticketpark\SaferpayJson\Container\Payer;
 use Ticketpark\SaferpayJson\Container\Payment;
+use Ticketpark\SaferpayJson\Container\RegisterAlias;
 use Ticketpark\SaferpayJson\Container\ReturnUrls;
+use Ticketpark\SaferpayJson\Container\Styling;
 use Ticketpark\SaferpayJson\Request\Request;
 use Ticketpark\SaferpayJson\Request\RequestCommonsTrait;
 use Ticketpark\SaferpayJson\Response\PaymentPage\InitializeResponse;
@@ -77,6 +79,18 @@ class InitializeRequest extends Request
      */
     protected $paymentMethods;
 
+    /**
+     * @var RegisterAlias|null
+     * @Serializer\SerializedName("RegisterAlias")
+     */
+    protected $registerAlias;
+
+    /**
+     * @var Styling|null
+     * @Serializer\SerializedName("Styling")
+     */
+    protected $styling;
+
     public function getPayment(): Payment
     {
         return $this->payment;
@@ -145,6 +159,30 @@ class InitializeRequest extends Request
     public function setPaymentMethods(array $paymentMethods): self
     {
         $this->paymentMethods = $paymentMethods;
+
+        return $this;
+    }
+
+    public function getRegisterAlias(): ?RegisterAlias
+    {
+        return $this->registerAlias;
+    }
+
+    public function setRegisterAlias(RegisterAlias $registerAlias): self
+    {
+        $this->registerAlias = $registerAlias;
+
+        return $this;
+    }
+
+    public function getStyling(): ?Styling
+    {
+        return $this->styling;
+    }
+
+    public function setStyling(Styling $styling): self
+    {
+        $this->styling = $styling;
 
         return $this;
     }

--- a/lib/SaferpayJson/Request/SecureAliasStore/InsertRequest.php
+++ b/lib/SaferpayJson/Request/SecureAliasStore/InsertRequest.php
@@ -59,8 +59,8 @@ class InsertRequest extends Request
 
     /**
      * @var string[]
-     * @Serializer\SerializedName("PaymentMethods")
-     * @Serializer\Type("array")
+     * @SerializedName("PaymentMethods")
+     * @Type("array")
      */
     protected $paymentMethods = [];
 

--- a/lib/SaferpayJson/Request/SecureAliasStore/InsertRequest.php
+++ b/lib/SaferpayJson/Request/SecureAliasStore/InsertRequest.php
@@ -57,6 +57,13 @@ class InsertRequest extends Request
      */
     protected $check;
 
+    /**
+     * @var string[]
+     * @Serializer\SerializedName("PaymentMethods")
+     * @Serializer\Type("array")
+     */
+    protected $paymentMethods = [];
+
     public function getRegisterAlias(): RegisterAlias
     {
         return $this->registerAlias;
@@ -89,6 +96,42 @@ class InsertRequest extends Request
     public function setReturnUrls(ReturnUrls $returnUrls): self
     {
         $this->returnUrls = $returnUrls;
+
+        return $this;
+    }
+
+    public function getPaymentMethods(): array
+    {
+        return $this->paymentMethods;
+    }
+
+    public function setPaymentMethods(array $paymentMethods): self
+    {
+        $this->paymentMethods = $paymentMethods;
+
+        return $this;
+    }
+
+    public function getStyling(): ?Styling
+    {
+        return $this->styling;
+    }
+
+    public function setStyling(Styling $styling): self
+    {
+        $this->styling = $styling;
+
+        return $this;
+    }
+
+    public function getCheck(): ?Check
+    {
+        return $this->check;
+    }
+
+    public function setCheck(Check $check): self
+    {
+        $this->check = $check;
 
         return $this;
     }

--- a/lib/SaferpayJson/Response/ErrorResponse.php
+++ b/lib/SaferpayJson/Response/ErrorResponse.php
@@ -9,7 +9,7 @@ class ErrorResponse extends Response
 {
     /**
      * @var string
-     * @SerializedName("Behaviour")
+     * @SerializedName("Behavior")
      * @Type("string")
      */
     protected $behaviour;
@@ -29,7 +29,7 @@ class ErrorResponse extends Response
     protected $errorMessage;
 
     /**
-     * @var string
+     * @var string|null
      * @SerializedName("TransactionId")
      * @Type("string")
      */
@@ -40,24 +40,24 @@ class ErrorResponse extends Response
      * @SerializedName("ErrorDetail")
      * @Type("array")
      */
-    protected $errorDetail;
+    protected $errorDetail = [];
 
     /**
-     * @var string
+     * @var string|null
      * @SerializedName("ProcessorName")
      * @Type("string")
      */
     protected $processorName;
 
     /**
-     * @var string
+     * @var string|null
      * @SerializedName("ProcessorResult")
      * @Type("string")
      */
     protected $processorResult;
 
     /**
-     * @var string
+     * @var string|null
      * @SerializedName("ProcessorMessage")
      * @Type("string")
      */
@@ -99,7 +99,7 @@ class ErrorResponse extends Response
         return $this;
     }
 
-    public function getTransactionId(): string
+    public function getTransactionId(): ?string
     {
         return $this->transactionId;
     }
@@ -123,7 +123,7 @@ class ErrorResponse extends Response
         return $this;
     }
 
-    public function getProcessorName(): string
+    public function getProcessorName(): ?string
     {
         return $this->processorName;
     }
@@ -135,7 +135,7 @@ class ErrorResponse extends Response
         return $this;
     }
 
-    public function getProcessorResult(): string
+    public function getProcessorResult(): ?string
     {
         return $this->processorResult;
     }
@@ -147,7 +147,7 @@ class ErrorResponse extends Response
         return $this;
     }
 
-    public function getProcessorMessage(): string
+    public function getProcessorMessage(): ?string
     {
         return $this->processorMessage;
     }

--- a/lib/SaferpayJson/Response/Transaction/CaptureResponse.php
+++ b/lib/SaferpayJson/Response/Transaction/CaptureResponse.php
@@ -37,6 +37,20 @@ class CaptureResponse extends Response
      */
     protected $invoice;
 
+    /**
+     * @var string
+     * @Serializer\SerializedName("Status")
+     * @Serializer\Type("string")
+     */
+    protected $status;
+
+    /**
+     * @var string
+     * @Serializer\SerializedName("CaptureId")
+     * @Serializer\Type("string")
+     */
+    protected $captureId;
+
     public function getTransactionId(): string
     {
         return $this->transactionId;
@@ -75,5 +89,29 @@ class CaptureResponse extends Response
     public function setInvoice(Invoice $invoice): void
     {
         $this->invoice = $invoice;
+    }
+    
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+        
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+    
+    public function setCaptureId(string $captureId): self
+    {
+        $this->captureId = $captureId;
+        
+        return $this;
+    }
+
+    public function getCaptureId(): string
+    {
+        return $this->captureId;
     }
 }

--- a/lib/SaferpayJson/Response/Transaction/CaptureResponse.php
+++ b/lib/SaferpayJson/Response/Transaction/CaptureResponse.php
@@ -39,15 +39,15 @@ class CaptureResponse extends Response
 
     /**
      * @var string
-     * @Serializer\SerializedName("Status")
-     * @Serializer\Type("string")
+     * @SerializedName("Status")
+     * @Type("string")
      */
     protected $status;
 
     /**
      * @var string
-     * @Serializer\SerializedName("CaptureId")
-     * @Serializer\Type("string")
+     * @SerializedName("CaptureId")
+     * @Type("string")
      */
     protected $captureId;
 


### PR DESCRIPTION
Add missing properties available in the saferpay api response
ResponseHeader: specVersion is string, not double
InitializeRequest: add registerAlias and styling properties
InsertRequest: add paymentMethods property, add access methods for styling and check
CaptureResponse: add status and captureId property
ErrorResponse: fix spelling of behaviour property to match the api property, add nullable type hints to prevent type errors