### PR TITLE
Support error responses

### DIFF
--- a/lib/SaferpayJson/Request/Request.php
+++ b/lib/SaferpayJson/Request/Request.php
@@ -4,6 +4,7 @@ namespace Ticketpark\SaferpayJson\Request;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
 use JMS\Serializer\Annotation\Exclude;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\SerializerBuilder;
@@ -139,11 +140,11 @@ abstract class Request
                 ]
             );
         } catch (\Exception $e) {
-            if ($e->getCode() >= 500) {
+            if ($e instanceof ClientException) {
+                $response = $e->getResponse();
+            } else {
                 throw new HttpRequestException($e->getMessage());
             }
-
-            $response = $e->getResponse();
         }
 
         $statusCode = $response->getStatusCode();

--- a/lib/SaferpayJson/Request/Request.php
+++ b/lib/SaferpayJson/Request/Request.php
@@ -139,7 +139,11 @@ abstract class Request
                 ]
             );
         } catch (\Exception $e) {
-            throw new HttpRequestException($e->getMessage());
+            if ($e->getCode() >= 500) {
+                throw new HttpRequestException($e->getMessage());
+            }
+
+            $response = $e->getResponse();
         }
 
         $statusCode = $response->getStatusCode();


### PR DESCRIPTION
Guzzle throws exceptions on http codes starting from 400. This causes all validation errors with HTTP 400 to throw an HttpRequestException, which prevents further processing of the error response
The error code of the exception seems always to be the http status code.
This fix throws exceptions for http 500 errors, but processes the error responses for http 400 errors

Tries to solve same issue as https://github.com/Ticketpark/SaferpayJsonApi/pull/16