### PR TITLE
Add missing properties as defined in API version 1.2

### DIFF
--- a/lib/SaferpayJson/Container/ResponseHeader.php
+++ b/lib/SaferpayJson/Container/ResponseHeader.php
@@ -10,7 +10,7 @@ class ResponseHeader
     /**
      * @var string
      * @SerializedName("SpecVersion")
-     * @Type("double")
+     * @Type("string")
      */
     protected $specVersion = '1.2';
 

--- a/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
@@ -6,7 +6,9 @@ use JMS\Serializer\Annotation\SerializedName;
 use Ticketpark\SaferpayJson\Container\Notification;
 use Ticketpark\SaferpayJson\Container\Payer;
 use Ticketpark\SaferpayJson\Container\Payment;
+use Ticketpark\SaferpayJson\Container\RegisterAlias;
 use Ticketpark\SaferpayJson\Container\ReturnUrls;
+use Ticketpark\SaferpayJson\Container\Styling;
 use Ticketpark\SaferpayJson\Request\Request;
 use Ticketpark\SaferpayJson\Request\RequestCommonsTrait;
 use Ticketpark\SaferpayJson\Response\PaymentPage\InitializeResponse;
@@ -77,6 +79,18 @@ class InitializeRequest extends Request
      */
     protected $paymentMethods;
 
+    /**
+     * @var RegisterAlias|null
+     * @SerializedName("RegisterAlias")
+     */
+    protected $registerAlias;
+
+    /**
+     * @var Styling|null
+     * @SerializedName("Styling")
+     */
+    protected $styling;
+
     public function getPayment(): Payment
     {
         return $this->payment;
@@ -145,6 +159,30 @@ class InitializeRequest extends Request
     public function setPaymentMethods(array $paymentMethods): self
     {
         $this->paymentMethods = $paymentMethods;
+
+        return $this;
+    }
+
+    public function getRegisterAlias(): ?RegisterAlias
+    {
+        return $this->registerAlias;
+    }
+
+    public function setRegisterAlias(RegisterAlias $registerAlias): self
+    {
+        $this->registerAlias = $registerAlias;
+
+        return $this;
+    }
+
+    public function getStyling(): ?Styling
+    {
+        return $this->styling;
+    }
+
+    public function setStyling(Styling $styling): self
+    {
+        $this->styling = $styling;
 
         return $this;
     }

--- a/lib/SaferpayJson/Request/SecureAliasStore/InsertRequest.php
+++ b/lib/SaferpayJson/Request/SecureAliasStore/InsertRequest.php
@@ -92,4 +92,28 @@ class InsertRequest extends Request
 
         return $this;
     }
+
+    public function getStyling(): ?Styling
+    {
+        return $this->styling;
+    }
+
+    public function setStyling(Styling $styling): self
+    {
+        $this->styling = $styling;
+
+        return $this;
+    }
+
+    public function getCheck(): ?Check
+    {
+        return $this->check;
+    }
+
+    public function setCheck(Check $check): self
+    {
+        $this->check = $check;
+
+        return $this;
+    }
 }

--- a/lib/SaferpayJson/Response/ErrorResponse.php
+++ b/lib/SaferpayJson/Response/ErrorResponse.php
@@ -9,7 +9,7 @@ class ErrorResponse extends Response
 {
     /**
      * @var string
-     * @SerializedName("Behaviour")
+     * @SerializedName("Behavior")
      * @Type("string")
      */
     protected $behaviour;
@@ -29,7 +29,7 @@ class ErrorResponse extends Response
     protected $errorMessage;
 
     /**
-     * @var string
+     * @var string|null
      * @SerializedName("TransactionId")
      * @Type("string")
      */
@@ -40,17 +40,17 @@ class ErrorResponse extends Response
      * @SerializedName("ErrorDetail")
      * @Type("array")
      */
-    protected $errorDetail;
+    protected $errorDetail = [];
 
     /**
-     * @var string
+     * @var string|null
      * @SerializedName("ProcessorName")
      * @Type("string")
      */
     protected $processorName;
 
     /**
-     * @var string
+     * @var string|null
      * @SerializedName("ProcessorResult")
      * @Type("string")
      */
@@ -99,7 +99,7 @@ class ErrorResponse extends Response
         return $this;
     }
 
-    public function getTransactionId(): string
+    public function getTransactionId(): ?string
     {
         return $this->transactionId;
     }
@@ -123,7 +123,7 @@ class ErrorResponse extends Response
         return $this;
     }
 
-    public function getProcessorName(): string
+    public function getProcessorName(): ?string
     {
         return $this->processorName;
     }
@@ -135,7 +135,7 @@ class ErrorResponse extends Response
         return $this;
     }
 
-    public function getProcessorResult(): string
+    public function getProcessorResult(): ?string
     {
         return $this->processorResult;
     }
@@ -147,7 +147,7 @@ class ErrorResponse extends Response
         return $this;
     }
 
-    public function getProcessorMessage(): string
+    public function getProcessorMessage(): ?string
     {
         return $this->processorMessage;
     }


### PR DESCRIPTION
Same as in #17, except: InsertRequest::$paymentMethods, CaptureResponse::$status, CaptureResponse::$captureId