### PR TITLE
Add missing properties as defined in API version 1.16

### DIFF
--- a/lib/SaferpayJson/Request/SecureAliasStore/InsertRequest.php
+++ b/lib/SaferpayJson/Request/SecureAliasStore/InsertRequest.php
@@ -57,6 +57,13 @@ class InsertRequest extends Request
      */
     protected $check;
 
+    /**
+     * @var string[]
+     * @SerializedName("PaymentMethods")
+     * @Type("array")
+     */
+    protected $paymentMethods = [];
+
     public function getRegisterAlias(): RegisterAlias
     {
         return $this->registerAlias;
@@ -89,6 +96,18 @@ class InsertRequest extends Request
     public function setReturnUrls(ReturnUrls $returnUrls): self
     {
         $this->returnUrls = $returnUrls;
+
+        return $this;
+    }
+
+    public function getPaymentMethods(): array
+    {
+        return $this->paymentMethods;
+    }
+
+    public function setPaymentMethods(array $paymentMethods): self
+    {
+        $this->paymentMethods = $paymentMethods;
 
         return $this;
     }

--- a/lib/SaferpayJson/Response/Transaction/CaptureResponse.php
+++ b/lib/SaferpayJson/Response/Transaction/CaptureResponse.php
@@ -37,6 +37,20 @@ class CaptureResponse extends Response
      */
     protected $invoice;
 
+    /**
+     * @var string
+     * @SerializedName("Status")
+     * @Type("string")
+     */
+    protected $status;
+
+    /**
+     * @var string
+     * @SerializedName("CaptureId")
+     * @Type("string")
+     */
+    protected $captureId;
+
     public function getTransactionId(): string
     {
         return $this->transactionId;
@@ -75,5 +89,29 @@ class CaptureResponse extends Response
     public function setInvoice(Invoice $invoice): void
     {
         $this->invoice = $invoice;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setCaptureId(string $captureId): self
+    {
+        $this->captureId = $captureId;
+
+        return $this;
+    }
+
+    public function getCaptureId(): string
+    {
+        return $this->captureId;
     }
 }


### PR DESCRIPTION
Same as in #17, but only InsertRequest::$paymentMethods, CaptureResponse::$status, CaptureResponse::$captureId
Other missing properties were included in PR #19