### PR TITLE
Allow jms/serializer ^3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 composer.lock
 vendor
 /.php_cs.cache
+.idea
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.3",
         "doctrine/annotations": "^1.7",
-        "jms/serializer": "^1.0",
+        "jms/serializer": "^1.0|^3.0",
         "guzzlehttp/guzzle": "^6.3|^7.0"
     },
     "require-dev": {

--- a/lib/SaferpayJson/Response/PaymentPage/InitializeResponse.php
+++ b/lib/SaferpayJson/Response/PaymentPage/InitializeResponse.php
@@ -34,7 +34,7 @@ final class InitializeResponse extends Response
         return $this->token;
     }
 
-    public function getExpiration(): ?\DateTime
+    public function getExpiration(): ?string
     {
         return $this->expiration;
     }

--- a/lib/SaferpayJson/Response/SecureCardData/AliasInsertResponse.php
+++ b/lib/SaferpayJson/Response/SecureCardData/AliasInsertResponse.php
@@ -42,7 +42,7 @@ final class AliasInsertResponse extends Response
         return $this->token;
     }
 
-    public function getExpiration(): ?\DateTime
+    public function getExpiration(): ?string
     {
         return $this->expiration;
     }


### PR DESCRIPTION
With this PR the Saferpay library can be used with the current version of the jms/serializer (https://github.com/schmittjoh/serializer)

Version ^1.0 can still be used but may be marked as deprecated as this version is no longer maintained.

I did not experience any errors with this version. I can use PaymentPage\AssertRequest, PaymentPage\InitializeRequest, SecureCardData\AliasAssertInsertRequest and SecureCardData\AliasInsertRequest without problems. The unit tests are also successful.

I also have fixed the type annotation to match the type of the serialisation annotation. Otherwise I got a type violation when calling the getter.