### PR TITLE
Bugfix: Wrong annotation namespace in CheckResult.php

### DIFF
--- a/lib/SaferpayJson/Response/Container/CheckResult.php
+++ b/lib/SaferpayJson/Response/Container/CheckResult.php
@@ -24,7 +24,7 @@ final class CheckResult
     /**
      * @var HolderAuthentication|null
      * @SerializedName("Authentication")
-     * @Type("Ticketpark\SaferpayJson\Container\HolderAuthentication")
+     * @Type("Ticketpark\SaferpayJson\Response\Container\HolderAuthentication")
      */
     private $authentication;
 


### PR DESCRIPTION
Fixes: "Class Ticketpark\\SaferpayJson\\Container\\HolderAuthentication does not exist" Exception

Reproduce: Create and execute AliasInsert Request with Check::TYPE_ONLINE_STRONG, e.g. :
```php
$check = (new Check())
            ->setType(Check::TYPE_ONLINE_STRONG)
            ->setTerminalId($terminalId);

$aliasInsertRequest = new AliasInsertRequest($saferpayConfig, $registerAlias, AliasInsertRequest::TYPE_CARD, $returnUrls);

$aliasInsertRequest->setCheck($check);

$aliasInsertRequest->execute();
``` 

Then follow the redirect link successfully and execute a AliasAssertInsertRequest.