### PR TITLE
Provide a message when raising a SaferpayErrorException

### DIFF
--- a/lib/SaferpayJson/Request/Exception/SaferpayErrorException.php
+++ b/lib/SaferpayJson/Request/Exception/SaferpayErrorException.php
@@ -13,7 +13,12 @@ class SaferpayErrorException extends \Exception
     {
         $this->errorResponse = $errorResponse;
 
-        parent::__construct();
+        parent::__construct(sprintf(
+            '[%s] %s: %s',
+            $errorResponse->getBehaviour(),
+            $errorResponse->getErrorName(),
+            $errorResponse->getErrorMessage()
+        ));
     }
 
     public function getErrorResponse(): ?ErrorResponse


### PR DESCRIPTION
Hi,

This patch adds a summary of the ErrorResponse as a message to the Exception constructor. When SaferpayErrorException ends up in logs or in tools such as sentry, the message is empty because it was never set in the constructor. This patch aims to address that. For the example error response in the [saferpay documentation](https://saferpay.github.io/jsonapi/#errorhandling) this would raise an Exception with the following message: `[ABORT] VALIDATION_FAILED: Request validation failed`.

Tests are not provided as the example responses from the test cases do not contain any data, so that is one area that we can look into.