### PR TITLE
Add Inquire request

### DIFF
--- a/lib/SaferpayJson/Request/Transaction/InquireRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/InquireRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Request\Transaction;
+
+use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Request\Container\TransactionReference;
+use Ticketpark\SaferpayJson\Request\Request;
+use Ticketpark\SaferpayJson\Request\RequestCommonsTrait;
+use Ticketpark\SaferpayJson\Request\RequestConfig;
+use Ticketpark\SaferpayJson\Response\Transaction\InquireResponse;
+
+final class InquireRequest extends Request
+{
+    use RequestCommonsTrait;
+    public const API_PATH = '/Payment/v1/Transaction/Inquire';
+    public const RESPONSE_CLASS = InquireResponse::class;
+
+    /**
+     * @var TransactionReference
+     * @SerializedName("TransactionReference")
+     */
+    private $transactionReference;
+
+    public function __construct(
+        RequestConfig $requestConfig,
+        TransactionReference $transactionReference
+    ) {
+        $this->transactionReference = $transactionReference;
+
+        parent::__construct($requestConfig);
+    }
+
+    public function getTransactionReference(): TransactionReference
+    {
+        return $this->transactionReference;
+    }
+
+    public function setTransactionReference(TransactionReference $transactionReference): self
+    {
+        $this->transactionReference = $transactionReference;
+
+        return $this;
+    }
+
+    public function execute(): InquireResponse
+    {
+        /** @var InquireResponse $response */
+        $response = $this->doExecute();
+
+        return $response;
+    }
+}

--- a/lib/SaferpayJson/Response/Transaction/InquireResponse.php
+++ b/lib/SaferpayJson/Response/Transaction/InquireResponse.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Response\Transaction;
+
+use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\Type;
+use Ticketpark\SaferpayJson\Response\Container\Dcc;
+use Ticketpark\SaferpayJson\Response\Container\Liability;
+use Ticketpark\SaferpayJson\Response\Container\Payer;
+use Ticketpark\SaferpayJson\Response\Container\PaymentMeans;
+use Ticketpark\SaferpayJson\Response\Container\Transaction;
+use Ticketpark\SaferpayJson\Response\Response;
+
+final class InquireResponse extends Response
+{
+    /**
+     * @var Transaction|null
+     * @SerializedName("Transaction")
+     * @Type("Ticketpark\SaferpayJson\Response\Container\Transaction")
+     */
+    private $transaction;
+
+    /**
+     * @var PaymentMeans|null
+     * @SerializedName("PaymentMeans")
+     * @Type("Ticketpark\SaferpayJson\Response\Container\PaymentMeans")
+     */
+    private $paymentMeans;
+
+    /**
+     * @var Payer|null
+     * @SerializedName("Payer")
+     * @Type("Ticketpark\SaferpayJson\Response\Container\Payer")
+     */
+    private $payer;
+
+    /**
+     * @var Liability|null
+     * @SerializedName("Liability")
+     * @Type("Ticketpark\SaferpayJson\Response\Container\Liability")
+     */
+    private $liability;
+
+    /**
+     * @var Dcc|null
+     * @SerializedName("Dcc")
+     * @Type("Ticketpark\SaferpayJson\Response\Container\Dcc")
+     */
+    private $dcc;
+
+    public function getTransaction(): ?Transaction
+    {
+        return $this->transaction;
+    }
+
+    public function getPaymentMeans(): ?PaymentMeans
+    {
+        return $this->paymentMeans;
+    }
+
+    public function getPayer(): ?Payer
+    {
+        return $this->payer;
+    }
+
+    public function getLiability(): ?Liability
+    {
+        return $this->liability;
+    }
+
+    public function getDcc(): ?Dcc
+    {
+        return $this->dcc;
+    }
+}


### PR DESCRIPTION
Hi,

Thanks for this great lib that we use extensively. I added the Transaction Inquire methods to be able to check the status of any transaction as stated in Saferpay json API specification 

> This method can be used to get the details of a transaction that has been authorized successfully.
https://saferpay.github.io/jsonapi/#Payment_v1_Transaction_Inquire

It's tested in version 4.4 in our production environements for many months.