### PR TITLE
Add retry mechanism via request header

### DIFF
--- a/example/Transaction/example-authorize-retry.php
+++ b/example/Transaction/example-authorize-retry.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+use Ticketpark\SaferpayJson\Request\Exception\SaferpayErrorException;
+use Ticketpark\SaferpayJson\Request\RequestConfig;
+use Ticketpark\SaferpayJson\Request\Transaction\AuthorizeRequest;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../credentials.php';
+
+// A token you received after initializing a transaction (see example-initialize.php)
+
+$token = 'xxx';
+
+// The request ID you received after the first authorize request fails with a Behavior of RETRY or RETRY_LATER
+
+$requestId = 'your_request_id';
+
+// retryIndicator is set to 1 to indicate that this is a retry (see SaferpayJson/Request/RequestConfig.php)
+
+$retryIndicator = 1;
+
+// -----------------------------
+// Step 1:
+// Prepare the authorize request
+// See https://saferpay.github.io/jsonapi/#Payment_v1_Transaction_Authorize
+//
+// Note: The RequestConfig is created with a requestId and retryIndicator to indicate that this is a retry
+// (see https://docs.saferpay.com/home/integration-guide/licences-and-interfaces/error-handling#the-requestid-and-retryindicator)
+
+$requestConfig = new RequestConfig(
+    $apiKey,
+    $apiSecret,
+    $customerId,
+    true,
+    $requestId,
+    $retryIndicator
+);
+
+// -----------------------------
+// Step 2:
+// Create the request with required data
+
+$authorizeRequest = new AuthorizeRequest(
+    $requestConfig,
+    $token,
+);
+
+// Note: More data can be provided to InitializeRequest with setters,
+// for example: $authorizeRequest->setCondition()
+// See Saferpay documentation for available options.
+
+// -----------------------------
+// Step 3:
+// Execute and check for successful response
+
+try {
+    $response = $authorizeRequest->execute();
+} catch (SaferpayErrorException $e) {
+    die ($e->getErrorResponse()->getErrorMessage());
+}
+
+echo 'The transaction has been successful! Transaction id: ' . $response->getTransaction()->getId() . "\n";
+
+// -----------------------------
+// Step 4:
+// Capture the transaction to get the cash flowing.
+// see: example-capture.php

--- a/lib/SaferpayJson/Request/Container/RequestHeader.php
+++ b/lib/SaferpayJson/Request/Container/RequestHeader.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Ticketpark\SaferpayJson\Request\Container;
 
+use InvalidArgumentException;
 use JMS\Serializer\Annotation\SerializedName;
 
 final class RequestHeader
 {
+    private const MIN_RETRY_INDICATOR = 0;
+    private const MAX_RETRY_INDICATOR = 9;
+
     /**
      * @SerializedName("SpecVersion")
      */
@@ -33,9 +37,19 @@ final class RequestHeader
      */
     private ?ClientInfo $clientInfo = null;
 
-    public function __construct(string $customerId, string $requestId = null, int $retryIndicator = 0)
+    public function __construct(string $customerId, string $requestId = null, int $retryIndicator = self::MIN_RETRY_INDICATOR)
     {
         $this->customerId = $customerId;
+
+        if ($retryIndicator < self::MIN_RETRY_INDICATOR || $retryIndicator > self::MAX_RETRY_INDICATOR) {
+            throw new InvalidArgumentException('Retry indicator range: inclusive between '
+                . self::MIN_RETRY_INDICATOR . '  and ' . self::MAX_RETRY_INDICATOR);
+        }
+
+        if ($retryIndicator > self::MIN_RETRY_INDICATOR && $requestId === null) {
+            throw new InvalidArgumentException('Request id must be set if retry indicator is greater than 0');
+        }
+
         $this->requestId = $requestId;
         $this->retryIndicator = $retryIndicator;
 

--- a/lib/SaferpayJson/Request/Container/RequestHeader.php
+++ b/lib/SaferpayJson/Request/Container/RequestHeader.php
@@ -37,8 +37,8 @@ final class RequestHeader
     public function __construct(
         string $customerId,
         string $requestId = null,
-        int    $retryIndicator = RequestConfig::MIN_RETRY_INDICATOR)
-    {
+        int    $retryIndicator = RequestConfig::MIN_RETRY_INDICATOR
+    ) {
         $this->customerId = $customerId;
         $this->requestId = $requestId;
         $this->retryIndicator = $retryIndicator;

--- a/lib/SaferpayJson/Request/Container/RequestHeader.php
+++ b/lib/SaferpayJson/Request/Container/RequestHeader.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace Ticketpark\SaferpayJson\Request\Container;
 
-use InvalidArgumentException;
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Request\RequestConfig;
 
 final class RequestHeader
 {
-    private const MIN_RETRY_INDICATOR = 0;
-    private const MAX_RETRY_INDICATOR = 9;
-
     /**
      * @SerializedName("SpecVersion")
      */
@@ -37,19 +34,12 @@ final class RequestHeader
      */
     private ?ClientInfo $clientInfo = null;
 
-    public function __construct(string $customerId, string $requestId = null, int $retryIndicator = self::MIN_RETRY_INDICATOR)
+    public function __construct(
+        string $customerId,
+        string $requestId = null,
+        int    $retryIndicator = RequestConfig::MIN_RETRY_INDICATOR)
     {
         $this->customerId = $customerId;
-
-        if ($retryIndicator < self::MIN_RETRY_INDICATOR || $retryIndicator > self::MAX_RETRY_INDICATOR) {
-            throw new InvalidArgumentException('Retry indicator range: inclusive between '
-                . self::MIN_RETRY_INDICATOR . '  and ' . self::MAX_RETRY_INDICATOR);
-        }
-
-        if ($retryIndicator > self::MIN_RETRY_INDICATOR && $requestId === null) {
-            throw new InvalidArgumentException('Request id must be set if retry indicator is greater than 0');
-        }
-
         $this->requestId = $requestId;
         $this->retryIndicator = $retryIndicator;
 

--- a/lib/SaferpayJson/Request/Request.php
+++ b/lib/SaferpayJson/Request/Request.php
@@ -50,7 +50,9 @@ abstract class Request
     public function getRequestHeader(): RequestHeader
     {
         return new RequestHeader(
-            $this->requestConfig->getCustomerId()
+            $this->requestConfig->getCustomerId(),
+            $this->requestConfig->getRequestId(),
+            $this->requestConfig->getRetryIndicator()
         );
     }
 

--- a/lib/SaferpayJson/Request/RequestConfig.php
+++ b/lib/SaferpayJson/Request/RequestConfig.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request;
 
 use GuzzleHttp\Client;
+use InvalidArgumentException;
 
 final class RequestConfig
 {
+    public const MIN_RETRY_INDICATOR = 0;
+    public const MAX_RETRY_INDICATOR = 9;
+
     private string $apiKey;
     private string $apiSecret;
     private string $customerId;
@@ -28,6 +32,16 @@ final class RequestConfig
         $this->apiSecret = $apiSecret;
         $this->customerId = $customerId;
         $this->test = $test;
+
+        if ($retryIndicator < self::MIN_RETRY_INDICATOR || $retryIndicator > self::MAX_RETRY_INDICATOR) {
+            throw new InvalidArgumentException('Retry indicator range: inclusive between '
+                . self::MIN_RETRY_INDICATOR . '  and ' . self::MAX_RETRY_INDICATOR);
+        }
+
+        if ($retryIndicator > self::MIN_RETRY_INDICATOR && $requestId === null) {
+            throw new InvalidArgumentException('Request id must be set if retry indicator is greater than 0');
+        }
+
         $this->requestId = $requestId;
         $this->retryIndicator = $retryIndicator;
     }

--- a/lib/SaferpayJson/Request/RequestConfig.php
+++ b/lib/SaferpayJson/Request/RequestConfig.php
@@ -13,13 +13,23 @@ final class RequestConfig
     private string $customerId;
     private bool $test;
     private ?Client $client = null;
+    private ?string $requestId;
+    private int $retryIndicator;
 
-    public function __construct(string $apiKey, string $apiSecret, string $customerId, bool $test = false)
+    public function __construct(
+        string  $apiKey,
+        string  $apiSecret,
+        string  $customerId,
+        bool    $test = false,
+        ?string $requestId = null,
+        int     $retryIndicator = 0)
     {
         $this->apiKey = $apiKey;
         $this->apiSecret = $apiSecret;
         $this->customerId = $customerId;
         $this->test = $test;
+        $this->requestId = $requestId;
+        $this->retryIndicator = $retryIndicator;
     }
 
     public function getApiKey(): string
@@ -56,5 +66,15 @@ final class RequestConfig
         }
 
         return $this->client;
+    }
+
+    public function getRequestId(): ?string
+    {
+        return $this->requestId;
+    }
+
+    public function getRetryIndicator(): int
+    {
+        return $this->retryIndicator;
     }
 }

--- a/lib/SaferpayJson/Request/RequestConfig.php
+++ b/lib/SaferpayJson/Request/RequestConfig.php
@@ -26,8 +26,8 @@ final class RequestConfig
         string  $customerId,
         bool    $test = false,
         ?string $requestId = null,
-        int     $retryIndicator = 0)
-    {
+        int     $retryIndicator = 0
+    ) {
         $this->apiKey = $apiKey;
         $this->apiSecret = $apiSecret;
         $this->customerId = $customerId;

--- a/tests/SaferpayJson/Tests/Request/CommonRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/CommonRequestTest.php
@@ -42,6 +42,9 @@ abstract class CommonRequestTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider getRequestConfigValidationParams
+     */
     public function testRequestConfigValidation(
         ?string $requestId,
         int     $retryIndicator,


### PR DESCRIPTION
Hi,

I'm currently working to retry an `AuthorizeRequest` after the first response indicates that the customer cannot approve at this time and returns a behavior of `RETRY_LATER`. I searched a little bit in the Saferpay documentation and in this article I found the information https://docs.saferpay.com/home/integration-guide/licences-and-interfaces/error-handling#the-requestid-and-retryindicator

You can signal the retry by setting the `requestId` with the identical value of the first try and increase the `retryIndicator` in the `requestHeader`. This sounds straight forward but unfortunately the `requestHeader` cannot be modified in the current release because the getter in the `Request.php ` always returns a new instance and only set the `customerId` and so with every call the requestIndicator is zero and the `requestId` is a new uuid.

I modified your `RequestConfig.php` to support the `requestId` and `retryIndicator` because in your current design every modification to the request is set via the config. Thats the reason why I did not implement it in the `Request.php` directly. But I'm pleased to recieve your feedback. 