### PR TITLE
feat(config): Make API URL Configurable via RequestConfig

### DIFF
--- a/lib/SaferpayJson/Request/Request.php
+++ b/lib/SaferpayJson/Request/Request.php
@@ -20,8 +20,6 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 abstract class Request
 {
-    private const ROOT_URL = 'https://www.saferpay.com/api';
-    private const ROOT_URL_TEST = 'https://test.saferpay.com/api';
     private const ERROR_RESPONSE_CLASS = ErrorResponse::class;
 
     /**
@@ -113,13 +111,7 @@ abstract class Request
 
     private function getUrl(): string
     {
-        $rootUrl = self::ROOT_URL;
-
-        if ($this->requestConfig->isTest()) {
-            $rootUrl = self::ROOT_URL_TEST;
-        }
-
-        return $rootUrl . $this->getApiPath();
+        return $this->requestConfig->getRootUrl() . $this->getApiPath();
     }
 
     private function getHeaders(): array

--- a/lib/SaferpayJson/Request/RequestConfig.php
+++ b/lib/SaferpayJson/Request/RequestConfig.php
@@ -11,10 +11,13 @@ final class RequestConfig
 {
     public const MIN_RETRY_INDICATOR = 0;
     public const MAX_RETRY_INDICATOR = 9;
+    private const ROOT_URL = 'https://www.saferpay.com/api';
+    private const ROOT_URL_TEST = 'https://test.saferpay.com/api';
 
     private string $apiKey;
     private string $apiSecret;
     private string $customerId;
+    private string $rootUrl;
     private bool $test;
 
     private ?Client $client = null;
@@ -25,12 +28,19 @@ final class RequestConfig
         string $apiKey,
         string $apiSecret,
         string $customerId,
-        bool   $test = false
+        bool   $test = false,
+        string $rootUrl = null
     ) {
         $this->apiKey = $apiKey;
         $this->apiSecret = $apiSecret;
         $this->customerId = $customerId;
         $this->test = $test;
+
+        if (null === $rootUrl) {
+            $this->rootUrl = ($test ? self::ROOT_URL_TEST : self::ROOT_URL);
+        } else {
+            $this->rootUrl = $rootUrl;
+        }
     }
 
     public function getApiKey(): string
@@ -99,5 +109,15 @@ final class RequestConfig
     public function getRetryIndicator(): int
     {
         return $this->retryIndicator;
+    }
+
+    public function getRootUrl(): string
+    {
+        return $this->rootUrl;
+    }
+
+    public function setRootUrl(string $rootUrl): void
+    {
+        $this->rootUrl = $rootUrl;
     }
 }


### PR DESCRIPTION
### 🔧 What’s Changed

This pull request introduces the ability to override the default Saferpay API URL by updating the following:

- **Moved Constants:**  
  The API root URLs (`https://www.saferpay.com/api` and `https://test.saferpay.com/api`) were moved from `Request.php` to `RequestConfig.php`.

- **Added Optional Parameter:**  
  The constructor of `RequestConfig` now accepts a 5th (optional) argument: `$rootUrl`.  
  If this parameter is omitted (`null`), the class behaves exactly as before — using the appropriate live or test URL based on the `$test` flag.

- **New Getter and Setter:**  
  Added `getRootUrl()` and `setRootUrl()` methods to manage the root URL if needed programmatically.

- **Updated Request Logic:**  
  The `Request` class now uses the URL from `RequestConfig::getRootUrl()` instead of hardcoded constants.

---

### 🎯 Motivation

In testing environments, it's often necessary to direct requests to a custom API endpoint.  
This change allows consumers of the library to provide a custom base URL for the Saferpay API — for example, to mock or proxy API responses — without affecting the default behavior.

---

### ✅ Impact and Compatibility

- ✅ **No Breaking Changes**  
  The new parameter is optional, and if not provided, the logic falls back to the original behavior using either the live or test API URLs.

- 🔄 **Fully Backward Compatible**  
  Existing implementations that rely on the default constructor signature and behavior remain unaffected.

---

### 🧪 How to Test

1. **Default behavior:**  
   Instantiate `RequestConfig` without the 5th parameter and verify that requests are sent to the default Saferpay live/test API URLs depending on the `$test` flag.

2. **Custom behavior:**  
   Provide a custom `$rootUrl` to the constructor and verify that requests are correctly routed to the custom URL.

3. **Regression check:**  
   Ensure that previously working integrations continue functioning without changes.

---

### 📎 Additional Notes

This change improves flexibility without compromising the existing API contract and should be safe to merge for all consumers.