### PR TITLE
feat(SJA-98): Version bump to 1.41

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Have a look at the [example folder](/example) for more.
 
 ## Documentation
 
-This library is currently [based on v1.40 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.40/index.html).
+This library is currently [based on v1.41 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.41/index.html).
 
 Find the most current documentation of the Saferpay JSON API here:<br>
 https://saferpay.github.io/jsonapi/

--- a/lib/SaferpayJson/Request/Container/ForeignRetailer.php
+++ b/lib/SaferpayJson/Request/Container/ForeignRetailer.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Request\Container;
+
+use JMS\Serializer\Annotation\SerializedName;
+
+final class ForeignRetailer
+{
+    /**
+     * @SerializedName("City")
+     */
+    private ?string $city;
+
+    /**
+     * @SerializedName("CountryCode")
+     */
+    private ?string $countryCode;
+
+    /**
+     * @SerializedName("Name")
+     */
+    private ?string $name;
+
+    /**
+     * @SerializedName("Street")
+     */
+    private ?string $street;
+
+    /**
+     * @SerializedName("Zip")
+     */
+    private ?string $zip;
+
+    public function getCity(): ?string
+    {
+        return $this->city;
+    }
+
+    public function setCity(?string $city): self
+    {
+        $this->city = $city;
+
+        return $this;
+    }
+
+    public function getCountryCode(): ?string
+    {
+        return $this->countryCode;
+    }
+
+    public function setCountryCode(?string $countryCode): self
+    {
+        $this->countryCode = $countryCode;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getStreet(): ?string
+    {
+        return $this->street;
+    }
+
+    public function setStreet(?string $street): self
+    {
+        $this->street = $street;
+
+        return $this;
+    }
+
+    public function getZip(): ?string
+    {
+        return $this->zip;
+    }
+
+    public function setZip(?string $zip): self
+    {
+        $this->zip = $zip;
+
+        return $this;
+    }
+}

--- a/lib/SaferpayJson/Request/Container/Marketplace.php
+++ b/lib/SaferpayJson/Request/Container/Marketplace.php
@@ -23,6 +23,11 @@ final class Marketplace
      */
     private ?Amount $feeRefund = null;
 
+    /**
+     * @SerializedName("ForeignRetailer")
+     */
+    private ?ForeignRetailer $foreignRetailer = null;
+
     public function __construct(string $submerchantId)
     {
         $this->submerchantId = $submerchantId;
@@ -53,6 +58,18 @@ final class Marketplace
     public function setFeeRefund(?Amount $feeRefund): self
     {
         $this->feeRefund = $feeRefund;
+
+        return $this;
+    }
+
+    public function getForeignRetailer(): ?ForeignRetailer
+    {
+        return $this->foreignRetailer;
+    }
+
+    public function setForeignRetailer(?ForeignRetailer $foreignRetailer): self
+    {
+        $this->foreignRetailer = $foreignRetailer;
 
         return $this;
     }

--- a/lib/SaferpayJson/Request/Container/RequestHeader.php
+++ b/lib/SaferpayJson/Request/Container/RequestHeader.php
@@ -12,7 +12,7 @@ final class RequestHeader
     /**
      * @SerializedName("SpecVersion")
      */
-    private string $specVersion = '1.40';
+    private string $specVersion = '1.41';
 
     /**
      * @SerializedName("CustomerId")


### PR DESCRIPTION
## 🆕 Support for Saferpay SpecVersion 1.41

---

### 🔧 What’s Changed

This PR adds support for **SpecVersion 1.41**, as introduced by Saferpay on **2024-07-02 (Sandbox)**.

Changes include:

- ✅ **Updated SpecVersion**
  - Changed default version in `RequestHeader` from `1.40` to `1.41`.

- 🌐 **New Container: `ForeignRetailer`**
  - Introduced new class `ForeignRetailer.php` under `Container/`.
  - Added it as an optional subcontainer to the `Marketplace` container.
  - Affects the following requests:
    - `Transaction/Capture`
    - `Transaction/MultipartCapture`

---

### 📎 Background

As part of Saferpay's latest API version (v1.41), the following changes were introduced:

- **New SpecVersion (1.41)**
- **New container**: `ForeignRetailer` inside `Marketplace`
- **Validation rules**: ISO-based pattern enforcement on `LanguageCode` in `Payer` and `AliasInsert`

These changes are now reflected in this library to maintain full compatibility with Saferpay's current API version.

---

### ✅ Impact and Compatibility

- ✅ Fully backward compatible with Saferpay APIs ≥ 1.41
- ⚠️ If used with older Saferpay APIs, the `ForeignRetailer` container or new validation rules might not be accepted — make sure your account is enabled for v1.41.
- 🧪 Tested in local implementation with Sandbox (2024-07-02 and later).

---

### 📌 Linked Issue

Closes [#98 – Add support for new SpecVersion 1.41](https://github.com/Ticketpark/SaferpayJsonApi/issues/98)