### PR TITLE
feat(SJA-102): Version bump to 1.42

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Have a look at the [example folder](/example) for more.
 
 ## Documentation
 
-This library is currently [based on v1.41 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.41/index.html).
+This library is currently [based on v1.42 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.42/index.html).
 
 Find the most current documentation of the Saferpay JSON API here:<br>
 https://saferpay.github.io/jsonapi/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Have a look at the [example folder](/example) for more.
 
 ## Documentation
 
-This library is currently [based on v1.40 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.40/index.html).
+This library is currently [based on v1.41 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.41/index.html).
 
 Find the most current documentation of the Saferpay JSON API here:<br>
 https://saferpay.github.io/jsonapi/

--- a/lib/SaferpayJson/Request/Container/ForeignRetailer.php
+++ b/lib/SaferpayJson/Request/Container/ForeignRetailer.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Request\Container;
+
+use JMS\Serializer\Annotation\SerializedName;
+
+final class ForeignRetailer
+{
+    /**
+     * @SerializedName("City")
+     */
+    private ?string $city;
+
+    /**
+     * @SerializedName("CountryCode")
+     */
+    private ?string $countryCode;
+
+    /**
+     * @SerializedName("Name")
+     */
+    private ?string $name;
+
+    /**
+     * @SerializedName("Street")
+     */
+    private ?string $street;
+
+    /**
+     * @SerializedName("Zip")
+     */
+    private ?string $zip;
+
+    public function getCity(): ?string
+    {
+        return $this->city;
+    }
+
+    public function setCity(?string $city): self
+    {
+        $this->city = $city;
+
+        return $this;
+    }
+
+    public function getCountryCode(): ?string
+    {
+        return $this->countryCode;
+    }
+
+    public function setCountryCode(?string $countryCode): self
+    {
+        $this->countryCode = $countryCode;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getStreet(): ?string
+    {
+        return $this->street;
+    }
+
+    public function setStreet(?string $street): self
+    {
+        $this->street = $street;
+
+        return $this;
+    }
+
+    public function getZip(): ?string
+    {
+        return $this->zip;
+    }
+
+    public function setZip(?string $zip): self
+    {
+        $this->zip = $zip;
+
+        return $this;
+    }
+}

--- a/lib/SaferpayJson/Request/Container/Marketplace.php
+++ b/lib/SaferpayJson/Request/Container/Marketplace.php
@@ -23,6 +23,11 @@ final class Marketplace
      */
     private ?Amount $feeRefund = null;
 
+    /**
+     * @SerializedName("ForeignRetailer")
+     */
+    private ?ForeignRetailer $foreignRetailer = null;
+
     public function __construct(string $submerchantId)
     {
         $this->submerchantId = $submerchantId;
@@ -53,6 +58,18 @@ final class Marketplace
     public function setFeeRefund(?Amount $feeRefund): self
     {
         $this->feeRefund = $feeRefund;
+
+        return $this;
+    }
+
+    public function getForeignRetailer(): ?ForeignRetailer
+    {
+        return $this->foreignRetailer;
+    }
+
+    public function setForeignRetailer(?ForeignRetailer $foreignRetailer): self
+    {
+        $this->foreignRetailer = $foreignRetailer;
 
         return $this;
     }

--- a/lib/SaferpayJson/Request/Container/RequestHeader.php
+++ b/lib/SaferpayJson/Request/Container/RequestHeader.php
@@ -12,7 +12,7 @@ final class RequestHeader
     /**
      * @SerializedName("SpecVersion")
      */
-    private string $specVersion = '1.41';
+    private string $specVersion = '1.42';
 
     /**
      * @SerializedName("CustomerId")

--- a/lib/SaferpayJson/Request/Container/RequestHeader.php
+++ b/lib/SaferpayJson/Request/Container/RequestHeader.php
@@ -12,7 +12,7 @@ final class RequestHeader
     /**
      * @SerializedName("SpecVersion")
      */
-    private string $specVersion = '1.40';
+    private string $specVersion = '1.41';
 
     /**
      * @SerializedName("CustomerId")

--- a/lib/SaferpayJson/Request/Container/Transaction/Ideal.php
+++ b/lib/SaferpayJson/Request/Container/Transaction/Ideal.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Request\Container\Transaction;
+
+use JMS\Serializer\Annotation\SerializedName;
+
+final class Ideal
+{
+    /**
+     * @SerializedName("AccountHolderName")
+     */
+    private string $accountHolderName;
+
+    public function __construct(string $accountHolderName)
+    {
+        $this->accountHolderName = $accountHolderName;
+    }
+
+    public function getAccountHolderName(): string
+    {
+        return $this->accountHolderName;
+    }
+}

--- a/lib/SaferpayJson/Request/Container/Transaction/PaymentMethodsOptions.php
+++ b/lib/SaferpayJson/Request/Container/Transaction/PaymentMethodsOptions.php
@@ -17,6 +17,24 @@ final class PaymentMethodsOptions
      */
     private $a2a;
 
+    /**
+     * @var Ideal|null
+     * @SerializedName("Ideal")
+     * @Type("Ticketpark\SaferpayJson\Request\Container\Transaction\Ideal")
+     */
+    private $ideal;
+
+    public function getIdeal(): ?Ideal
+    {
+        return $this->ideal;
+    }
+
+    public function setIdeal(?Ideal $ideal): self
+    {
+        $this->ideal = $ideal;
+        return $this;
+    }
+
     public function getA2a(): ?A2a
     {
         return $this->a2a;


### PR DESCRIPTION
## 🆕 Support for Saferpay SpecVersion 1.42

---

### 🔧 What’s Changed
This PR adds support for SpecVersion 1.42.

Changes include:

- ✅ **Updated SpecVersion**
  - Changed default version in `RequestHeader` from `1.41` to `1.42`.

- 🌐 **New RequestContainer: `Transaction/Ideal`**
  - Introduced new class `Ideal.php` under `Request/Container/Transaction/`.
  - Affects the following ressource:
    - `Transaction/PaymentMethodsOptions`

---

### 📎 Background

As part of Saferpay's latest API version (v1.42), the following changes were introduced:

- **New SpecVersion (1.42)**
- **New paymentmethodsoptions**: `Ideal` inside `Transaction`

These changes are now reflected in this library to maintain full compatibility with Saferpay's current API version.

---

### ✅ Impact and Compatibility

- ⚠️ If used with older Saferpay APIs, the `Ideal` paymentmethod option might not be accepted — make sure your account is enabled for v1.42.
- 🧪 Tested in local implementation with Sandbox.

---

### 📌 Linked Issue

Closes [#102 – Add support for new SpecVersion 1.42](https://github.com/Ticketpark/SaferpayJsonApi/issues/102)
Based on [feat(SJA-98): Version bump to 1.41](https://github.com/Ticketpark/SaferpayJsonApi/pull/105)