### PR TITLE
feat: Version bump to 1.43

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Have a look at the [example folder](/example) for more.
 
 ## Documentation
 
-This library is currently [based on v1.42 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.42/index.html).
+This library is currently [based on v1.43 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.43/index.html).
 
 Find the most current documentation of the Saferpay JSON API here:<br>
 https://saferpay.github.io/jsonapi/

--- a/lib/SaferpayJson/Request/Container/MerchantFundDistributor.php
+++ b/lib/SaferpayJson/Request/Container/MerchantFundDistributor.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Request\Container;
+
+use JMS\Serializer\Annotation\SerializedName;
+
+final class MerchantFundDistributor
+{
+    /**
+     * @SerializedName("ForeignRetailer")
+     */
+    private ?ForeignRetailer $foreignRetailer = null;
+
+    public function getForeignRetailer(): ?ForeignRetailer
+    {
+        return $this->foreignRetailer;
+    }
+
+    public function setForeignRetailer(?ForeignRetailer $foreignRetailer): self
+    {
+        $this->foreignRetailer = $foreignRetailer;
+
+        return $this;
+    }
+}

--- a/lib/SaferpayJson/Request/Container/RequestHeader.php
+++ b/lib/SaferpayJson/Request/Container/RequestHeader.php
@@ -12,7 +12,7 @@ final class RequestHeader
     /**
      * @SerializedName("SpecVersion")
      */
-    private string $specVersion = '1.42';
+    private string $specVersion = '1.43';
 
     /**
      * @SerializedName("CustomerId")

--- a/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
@@ -59,6 +59,7 @@ final class InitializeRequest extends Request
 
     public const WALLET_APPLEPAY = "APPLEPAY";
     public const WALLET_GOOGLEPAY = "GOOGLEPAY";
+    public const WALLET_CLICKTOPAY = "CLICKTOPAY";
 
     public const CONDITION_THREE_DS_AUTHENTICATION_SUCCESSFUL_OR_ATTEMPTED = 'THREE_DS_AUTHENTICATION_SUCCESSFUL_OR_ATTEMPTED';
     public const CONDITION_NONE = 'NONE';

--- a/lib/SaferpayJson/Request/Transaction/CaptureRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/CaptureRequest.php
@@ -8,6 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 use Ticketpark\SaferpayJson\Request\Container\Amount;
 use Ticketpark\SaferpayJson\Request\Container\Billpay;
 use Ticketpark\SaferpayJson\Request\Container\Marketplace;
+use Ticketpark\SaferpayJson\Request\Container\MerchantFundDistributor;
 use Ticketpark\SaferpayJson\Request\Container\MastercardIssuerInstallments;
 use Ticketpark\SaferpayJson\Request\Container\PendingNotification;
 use Ticketpark\SaferpayJson\Request\Container\TransactionReference;
@@ -51,6 +52,11 @@ final class CaptureRequest extends Request
      * @SerializedName("MastercardIssuerInstallments")
      */
     private ?MastercardIssuerInstallments $mastercardIssuerInstallments = null;
+
+    /**
+     * @SerializedName("MerchantFundDistributor")
+     */
+    private ?MerchantFundDistributor $merchantFundDistributor = null;
 
     public function __construct(
         RequestConfig $requestConfig,
@@ -129,6 +135,18 @@ final class CaptureRequest extends Request
     public function setMastercardIssuerInstallments(?MastercardIssuerInstallments $mastercardIssuerInstallments): self
     {
         $this->mastercardIssuerInstallments = $mastercardIssuerInstallments;
+
+        return $this;
+    }
+
+    public function getMerchantFundDistributor(): ?MerchantFundDistributor
+    {
+        return $this->merchantFundDistributor;
+    }
+
+    public function setMerchantFundDistributor(?MerchantFundDistributor $merchantFundDistributor): self
+    {
+        $this->merchantFundDistributor = $merchantFundDistributor;
 
         return $this;
     }


### PR DESCRIPTION
Closes #103

- Bump `SpecVersion` to 1.43
- Add `MerchantFundDistributor` container with `ForeignRetailer` subcontainer and wire it into `Transaction/Capture`
- Add `CLICKTOPAY` wallet constant to `PaymentPage/Initialize`
- Update README documentation link to [v1.43](https://saferpay.github.io/jsonapi/1.43/index.html)


