### PR TITLE
feat: Version bump to 1.44

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Have a look at the [example folder](/example) for more.
 
 ## Documentation
 
-This library is currently [based on v1.43 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.43/index.html).
+This library is currently [based on v1.44 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.44/index.html).
 
 Find the most current documentation of the Saferpay JSON API here:<br>
 https://saferpay.github.io/jsonapi/

--- a/lib/SaferpayJson/Request/Container/RequestHeader.php
+++ b/lib/SaferpayJson/Request/Container/RequestHeader.php
@@ -12,7 +12,7 @@ final class RequestHeader
     /**
      * @SerializedName("SpecVersion")
      */
-    private string $specVersion = '1.43';
+    private string $specVersion = '1.44';
 
     /**
      * @SerializedName("CustomerId")

--- a/lib/SaferpayJson/Response/Container/Card.php
+++ b/lib/SaferpayJson/Response/Container/Card.php
@@ -48,6 +48,11 @@ final class Card
      */
     private ?string $hashValue = null;
 
+    /**
+     * @SerializedName("TokenPan")
+     */
+    private ?TokenPan $tokenPan = null;
+
     public function getMaskedNumber(): ?string
     {
         return $this->maskedNumber;
@@ -81,5 +86,10 @@ final class Card
     public function getHashValue(): ?string
     {
         return $this->hashValue;
+    }
+
+    public function getTokenPan(): ?TokenPan
+    {
+        return $this->tokenPan;
     }
 }

--- a/lib/SaferpayJson/Response/Container/TokenPan.php
+++ b/lib/SaferpayJson/Response/Container/TokenPan.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Response\Container;
+
+use JMS\Serializer\Annotation\SerializedName;
+
+final class TokenPan
+{
+    /**
+     * @SerializedName("MaskedNumber")
+     */
+    private ?string $maskedNumber = null;
+
+    /**
+     * @SerializedName("ExpYear")
+     */
+    private ?int $expYear = null;
+
+    /**
+     * @SerializedName("ExpMonth")
+     */
+    private ?int $expMonth = null;
+
+    public function getMaskedNumber(): ?string
+    {
+        return $this->maskedNumber;
+    }
+
+    public function getExpYear(): ?int
+    {
+        return $this->expYear;
+    }
+
+    public function getExpMonth(): ?int
+    {
+        return $this->expMonth;
+    }
+}


### PR DESCRIPTION
Closes #107

- Bump `SpecVersion` to 1.44
- Add `TokenPan` response container for masked scheme token PAN and expiry
- Wire `TokenPan` into response `Card` container
