### PR TITLE
feat: Version bump to 1.49

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Have a look at the [example folder](/example) for more.
 
 ## Documentation
 
-This library is currently [based on v1.48 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.48/index.html).
+This library is currently [based on v1.49 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.49/index.html).
 
 Find the most current documentation of the Saferpay JSON API here:<br>
 https://saferpay.github.io/jsonapi/

--- a/lib/SaferpayJson/Request/Container/DccReference.php
+++ b/lib/SaferpayJson/Request/Container/DccReference.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Request\Container;
+
+use JMS\Serializer\Annotation\SerializedName;
+
+final class DccReference
+{
+    /**
+     * @SerializedName("SelectedCurrencyCode")
+     */
+    private string $selectedCurrencyCode;
+
+    /**
+     * @SerializedName("Token")
+     */
+    private string $token;
+
+    public function __construct(string $selectedCurrencyCode, string $token)
+    {
+        $this->selectedCurrencyCode = $selectedCurrencyCode;
+        $this->token = $token;
+    }
+
+    public function getSelectedCurrencyCode(): string
+    {
+        return $this->selectedCurrencyCode;
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+}

--- a/lib/SaferpayJson/Request/Container/RequestHeader.php
+++ b/lib/SaferpayJson/Request/Container/RequestHeader.php
@@ -12,7 +12,7 @@ final class RequestHeader
     /**
      * @SerializedName("SpecVersion")
      */
-    private string $specVersion = '1.48';
+    private string $specVersion = '1.49';
 
     /**
      * @SerializedName("CustomerId")

--- a/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
@@ -36,7 +36,6 @@ final class InitializeRequest extends Request
     public const PAYMENT_METHOD_DIRECTDEBIT = 'DIRECTDEBIT';
     public const PAYMENT_METHOD_EPRZELEWY = 'EPRZELEWY';
     public const PAYMENT_METHOD_EPS = 'EPS';
-    public const PAYMENT_METHOD_GIROPAY = 'GIROPAY';
     public const PAYMENT_METHOD_IDEAL = 'IDEAL';
     public const PAYMENT_METHOD_INVOICE = 'INVOICE';
     public const PAYMENT_METHOD_JCB = 'JCB';
@@ -44,17 +43,15 @@ final class InitializeRequest extends Request
     public const PAYMENT_METHOD_MAESTRO = 'MAESTRO';
     public const PAYMENT_METHOD_MASTERCARD = 'MASTERCARD';
     public const PAYMENT_METHOD_PAYCONIQ = 'PAYCONIQ';
-    public const PAYMENT_METHOD_PAYDIREKT = 'PAYDIREKT';
     public const PAYMENT_METHOD_PAYPAL = 'PAYPAL';
     public const PAYMENT_METHOD_POSTFINANCEPAY = 'POSTFINANCEPAY';
     public const PAYMENT_METHOD_REKA = 'REKA';
     public const PAYMENT_METHOD_SAFERPAYTEST = 'SAFERPAYTEST';
-    public const PAYMENT_METHOD_SOFORT = 'SOFORT';
     public const PAYMENT_METHOD_TWINT = 'TWINT';
     public const PAYMENT_METHOD_UNIONPAY = 'UNIONPAY';
     public const PAYMENT_METHOD_VISA = 'VISA';
+    public const PAYMENT_METHOD_WERO = 'WERO';
     public const PAYMENT_METHOD_WECHATPAY = 'WECHATPAY';
-    public const PAYMENT_METHOD_WLCRYPTOPAYMENTS = 'WLCRYPTOPAYMENTS';
 
     public const WALLET_APPLEPAY = 'APPLEPAY';
     public const WALLET_GOOGLEPAY = 'GOOGLEPAY';

--- a/lib/SaferpayJson/Request/SecureCardData/AliasInsertRequest.php
+++ b/lib/SaferpayJson/Request/SecureCardData/AliasInsertRequest.php
@@ -32,8 +32,8 @@ final class AliasInsertRequest extends Request
     public const PAYMENT_METHOD_POSTFINANCEPAY = 'POSTFINANCEPAY';
     public const PAYMENT_METHOD_SAFERPAYTEST = 'SAFERPAYTEST';
     public const PAYMENT_METHOD_VISA = 'VISA';
+    public const PAYMENT_METHOD_WERO = 'WERO';
     public const PAYMENT_METHOD_WECHATPAY = 'WECHATPAY';
-    public const PAYMENT_METHOD_WLCRYPTOPAYMENTS = 'WLCRYPTOPAYMENTS';
 
     public const TYPE_CARD = 'CARD';
     public const TYPE_BANK_ACCOUNT = 'BANK_ACCOUNT';

--- a/lib/SaferpayJson/Request/Transaction/AuthorizeDirectRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/AuthorizeDirectRequest.php
@@ -6,6 +6,7 @@ namespace Ticketpark\SaferpayJson\Request\Transaction;
 
 use JMS\Serializer\Annotation\SerializedName;
 use Ticketpark\SaferpayJson\Request\Container\Authentication;
+use Ticketpark\SaferpayJson\Request\Container\DccReference;
 use Ticketpark\SaferpayJson\Request\Container\Order;
 use Ticketpark\SaferpayJson\Request\Container\Payer;
 use Ticketpark\SaferpayJson\Request\Container\Payment;
@@ -45,6 +46,11 @@ final class AuthorizeDirectRequest extends Request
      * @SerializedName("Authentication")
      */
     private ?Authentication $authentication = null;
+
+    /**
+     * @SerializedName("Dcc")
+     */
+    private ?DccReference $dcc = null;
 
     /**
      * @SerializedName("RegisterAlias")
@@ -128,6 +134,18 @@ final class AuthorizeDirectRequest extends Request
     public function setAuthentication(?Authentication $authentication): self
     {
         $this->authentication = $authentication;
+
+        return $this;
+    }
+
+    public function getDcc(): ?DccReference
+    {
+        return $this->dcc;
+    }
+
+    public function setDcc(?DccReference $dcc): self
+    {
+        $this->dcc = $dcc;
 
         return $this;
     }

--- a/lib/SaferpayJson/Request/Transaction/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/InitializeRequest.php
@@ -36,6 +36,7 @@ final class InitializeRequest extends Request
     public const PAYMENT_METHOD_MASTERCARD = 'MASTERCARD';
     public const PAYMENT_METHOD_REKA = 'REKA';
     public const PAYMENT_METHOD_VISA = 'VISA';
+    public const PAYMENT_METHOD_WERO = 'WERO';
     public const PAYMENT_METHOD_WECHATPAY = 'WECHATPAY';
 
     public const WALLET_MASTERPASS = 'MASTERPASS';

--- a/lib/SaferpayJson/Response/Container/Brand.php
+++ b/lib/SaferpayJson/Response/Container/Brand.php
@@ -15,23 +15,21 @@ final class Brand
     public const PAYMENT_METHOD_DIRECTDEBIT = 'DIRECTDEBIT';
     public const PAYMENT_METHOD_EPRZELEWY = 'EPRZELEWY';
     public const PAYMENT_METHOD_EPS = 'EPS';
-    public const PAYMENT_METHOD_GIROPAY = 'GIROPAY';
     public const PAYMENT_METHOD_IDEAL = 'IDEAL';
     public const PAYMENT_METHOD_INVOICE = 'INVOICE';
     public const PAYMENT_METHOD_JCB = 'JCB';
     public const PAYMENT_METHOD_KLARNA = 'KLARNA';
     public const PAYMENT_METHOD_MAESTRO = 'MAESTRO';
     public const PAYMENT_METHOD_MASTERCARD = 'MASTERCARD';
-    public const PAYMENT_METHOD_PAYDIREKT = 'PAYDIREKT';
     public const PAYMENT_METHOD_PAYPAL = 'PAYPAL';
     public const PAYMENT_METHOD_POSTCARD = 'POSTCARD';
     public const PAYMENT_METHOD_POSTFINANCE = 'POSTFINANCE';
     public const PAYMENT_METHOD_REKA = 'REKA';
-    public const PAYMENT_METHOD_SOFORT = 'SOFORT';
     public const PAYMENT_METHOD_TWINT = 'TWINT';
     public const PAYMENT_METHOD_UNIONPAY = 'UNIONPAY';
     public const PAYMENT_METHOD_VISA = 'VISA';
     public const PAYMENT_METHOD_VPAY = 'VPAY';
+    public const PAYMENT_METHOD_WERO = 'WERO';
     public const PAYMENT_METHOD_WECHATPAY = 'WECHATPAY';
 
     /**


### PR DESCRIPTION
Closes #114

- Bump SpecVersion to 1.49
- Add `WERO` payment method constant
- Add `DccReference` container to `Transaction/AuthorizeDirect`
- Remove deprecated payment methods `GIROPAY`, `PAYDIREKT`, `SOFORT`, and `WLCRYPTOPAYMENTS`

Made with [Cursor](https://cursor.com)