### PR TITLE
feat: Version bump to 1.51

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Have a look at the [example folder](/example) for more.
 
 ## Documentation
 
-This library is currently [based on v1.50 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.50/index.html).
+This library is currently [based on v1.51 of the Saferpay JSON API](https://saferpay.github.io/jsonapi/1.51/index.html).
 
 Find the most current documentation of the Saferpay JSON API here:<br>
 https://saferpay.github.io/jsonapi/

--- a/lib/SaferpayJson/Request/Container/ForeignRetailer.php
+++ b/lib/SaferpayJson/Request/Container/ForeignRetailer.php
@@ -11,27 +11,32 @@ final class ForeignRetailer
     /**
      * @SerializedName("City")
      */
-    private ?string $city;
+    private ?string $city = null;
 
     /**
      * @SerializedName("CountryCode")
      */
-    private ?string $countryCode;
+    private string $countryCode;
 
     /**
      * @SerializedName("Name")
      */
-    private ?string $name;
+    private ?string $name = null;
 
     /**
      * @SerializedName("Street")
      */
-    private ?string $street;
+    private ?string $street = null;
 
     /**
      * @SerializedName("Zip")
      */
-    private ?string $zip;
+    private ?string $zip = null;
+
+    public function __construct(string $countryCode)
+    {
+        $this->countryCode = $countryCode;
+    }
 
     public function getCity(): ?string
     {
@@ -45,16 +50,9 @@ final class ForeignRetailer
         return $this;
     }
 
-    public function getCountryCode(): ?string
+    public function getCountryCode(): string
     {
         return $this->countryCode;
-    }
-
-    public function setCountryCode(?string $countryCode): self
-    {
-        $this->countryCode = $countryCode;
-
-        return $this;
     }
 
     public function getName(): ?string

--- a/lib/SaferpayJson/Request/Container/RequestHeader.php
+++ b/lib/SaferpayJson/Request/Container/RequestHeader.php
@@ -12,7 +12,7 @@ final class RequestHeader
     /**
      * @SerializedName("SpecVersion")
      */
-    private string $specVersion = '1.50';
+    private string $specVersion = '1.51';
 
     /**
      * @SerializedName("CustomerId")

--- a/lib/SaferpayJson/Response/Container/AuthenticationResult.php
+++ b/lib/SaferpayJson/Response/Container/AuthenticationResult.php
@@ -8,22 +8,35 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class AuthenticationResult
 {
-    public const RESULT_OK = 'OK';
-    public const RESULT_NOT_SUPPORTED = 'NOT_SUPPORTED';
+    public const AUTHENTICATION_TYPE_STRONG_CUSTOMER_AUTHENTICATION = 'STRONG_CUSTOMER_AUTHENTICATION';
+    public const AUTHENTICATION_TYPE_FRICTIONLESS = 'FRICTIONLESS';
+    public const AUTHENTICATION_TYPE_ATTEMPT = 'ATTEMPT';
+    public const AUTHENTICATION_TYPE_UNSPECIFIED = 'UNSPECIFIED';
+    public const AUTHENTICATION_TYPE_NONE = 'NONE';
 
     /**
-     * @SerializedName("Result")
+     * @SerializedName("Authenticated")
      */
-    private ?string $result = null;
+    private ?bool $authenticated = null;
+
+    /**
+     * @SerializedName("AuthenticationType")
+     */
+    private ?string $authenticationType = null;
 
     /**
      * @SerializedName("Message")
      */
     private ?string $message = null;
 
-    public function getResult(): ?string
+    public function isAuthenticated(): ?bool
     {
-        return $this->result;
+        return $this->authenticated;
+    }
+
+    public function getAuthenticationType(): ?string
+    {
+        return $this->authenticationType;
     }
 
     public function getMessage(): ?string

--- a/lib/SaferpayJson/Response/Container/Card.php
+++ b/lib/SaferpayJson/Response/Container/Card.php
@@ -13,6 +13,11 @@ final class Card
     public const HOLDER_SEGMENT_CORPORATE = 'CORPORATE';
     public const HOLDER_SEGMENT_CORPORATE_AND_CONSUMER = 'CORPORATE_AND_CONSUMER';
 
+    public const FUNDING_SOURCE_UNSPECIFIED = 'UNSPECIFIED';
+    public const FUNDING_SOURCE_CREDIT = 'CREDIT';
+    public const FUNDING_SOURCE_DEBIT = 'DEBIT';
+    public const FUNDING_SOURCE_PREPAID = 'PREPAID';
+
     /**
      * @SerializedName("MaskedNumber")
      */
@@ -37,6 +42,11 @@ final class Card
      * @SerializedName("HolderSegment")
      */
     private ?string $holderSegment = null;
+
+    /**
+     * @SerializedName("FundingSource")
+     */
+    private ?string $fundingSource = null;
 
     /**
      * @SerializedName("CountryCode")
@@ -76,6 +86,11 @@ final class Card
     public function getHolderSegment(): ?string
     {
         return $this->holderSegment;
+    }
+
+    public function getFundingSource(): ?string
+    {
+        return $this->fundingSource;
     }
 
     public function getCountryCode(): ?string


### PR DESCRIPTION
Closes #116

- Bump SpecVersion to 1.51
- Update `AuthenticationResult` response container: replace `Result` with `Authenticated` and `AuthenticationType`
- Add `FundingSource` to `Card` response container
- Make `CountryCode` mandatory on `ForeignRetailer` request container

Made with [Cursor](https://cursor.com)