### PR TITLE
Drop Guzzle 6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "~7.4|~8.0.0|~8.1.0|~8.2.0|~8.3.0|~8.4.0|~8.5.0",
         "doctrine/annotations": "^1.11|^2.0",
         "jms/serializer": "^3.16",
-        "guzzlehttp/guzzle": "^6.3|^7.0"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/tests/SaferpayJson/Tests/Request/CommonRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/CommonRequestTest.php
@@ -98,11 +98,9 @@ abstract class CommonRequestTest extends TestCase
 
     private function getClientMock(): MockObject
     {
-        $mockMethod = $this->getMockMethodBasedOnGuzzleVersion();
-
         $browser = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->$mockMethod(['post'])
+            ->onlyMethods(['post'])
             ->getMock();
 
         $browser->expects($this->once())
@@ -146,19 +144,8 @@ abstract class CommonRequestTest extends TestCase
         return SerializerFactory::get()->serialize($response, 'json');
     }
 
-    private function getMockMethodBasedOnGuzzleVersion()
-    {
-        $reflection = new \ReflectionClass(Client::class);
-
-        return count($reflection->getTraits()) ? 'onlyMethods' : 'addMethods';
-    }
-
     private function getBodyContent(string $content)
     {
-        if (class_exists(GuzzleUtils::class)) {
-            return GuzzleUtils::streamFor($content);
-        }
-
-        return $content;
+        return GuzzleUtils::streamFor($content);
     }
 }


### PR DESCRIPTION
Closes #120

- Require `guzzlehttp/guzzle` ^7.0
- Remove Guzzle 6 compatibility shims from `CommonRequestTest` (`onlyMethods`/`addMethods` detection and `GuzzleUtils` fallback)


Made with [Cursor](https://cursor.com)