### PR TITLE
fix: Improve exception handling

### DIFF
--- a/lib/SaferpayJson/Request/Exception/SaferpayErrorException.php
+++ b/lib/SaferpayJson/Request/Exception/SaferpayErrorException.php
@@ -6,7 +6,7 @@ namespace Ticketpark\SaferpayJson\Request\Exception;
 
 use Ticketpark\SaferpayJson\Response\ErrorResponse;
 
-class SaferpayErrorException extends \Exception
+class SaferpayErrorException extends \Exception implements SaferpayException
 {
     private ErrorResponse $errorResponse;
 
@@ -22,7 +22,7 @@ class SaferpayErrorException extends \Exception
         ));
     }
 
-    public function getErrorResponse(): ?ErrorResponse
+    public function getErrorResponse(): ErrorResponse
     {
         return $this->errorResponse;
     }

--- a/lib/SaferpayJson/Request/Exception/SaferpayException.php
+++ b/lib/SaferpayJson/Request/Exception/SaferpayException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Ticketpark\SaferpayJson\Request\Exception;
 
-class HttpRequestException extends \Exception implements SaferpayException
+interface SaferpayException extends \Throwable
 {
 }

--- a/lib/SaferpayJson/Request/Request.php
+++ b/lib/SaferpayJson/Request/Request.php
@@ -72,7 +72,7 @@ abstract class Request
             );
         } catch (\Exception $e) {
             if (!$e instanceof ClientException) {
-                throw new HttpRequestException($e->getMessage());
+                throw new HttpRequestException($e->getMessage(), 0, $e);
             }
 
             /** @var GuzzleResponse $response */

--- a/tests/SaferpayJson/Tests/Request/CommonRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/CommonRequestTest.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Psr7\Utils as GuzzleUtils;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Ticketpark\SaferpayJson\Request\Exception\SaferpayErrorException;
+use Ticketpark\SaferpayJson\Request\Exception\SaferpayException;
 use Ticketpark\SaferpayJson\Request\RequestConfig;
 use Ticketpark\SaferpayJson\Response\ErrorResponse;
 use Ticketpark\SaferpayJson\Response\Response;
@@ -25,10 +26,15 @@ abstract class CommonRequestTest extends TestCase
 
     public function testErrorResponse(): void
     {
-        $this->expectException(SaferpayErrorException::class);
-
         $this->successful = false;
-        $this->executeRequest();
+
+        try {
+            $this->executeRequest();
+            $this->fail('Expected SaferpayErrorException');
+        } catch (SaferpayErrorException $e) {
+            $this->assertInstanceOf(ErrorResponse::class, $e->getErrorResponse());
+            $this->assertInstanceOf(SaferpayException::class, $e);
+        }
     }
 
     public function getRequestConfigValidationParams(): array

--- a/tests/SaferpayJson/Tests/Request/ExceptionTest.php
+++ b/tests/SaferpayJson/Tests/Request/ExceptionTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Tests\Request;
+
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+use Ticketpark\SaferpayJson\Request\Container\TransactionReference;
+use Ticketpark\SaferpayJson\Request\Exception\HttpRequestException;
+use Ticketpark\SaferpayJson\Request\Exception\SaferpayErrorException;
+use Ticketpark\SaferpayJson\Request\Exception\SaferpayException;
+use Ticketpark\SaferpayJson\Request\RequestConfig;
+use Ticketpark\SaferpayJson\Request\Transaction\CancelRequest;
+use Ticketpark\SaferpayJson\Response\ErrorResponse;
+use Ticketpark\SaferpayJson\SerializerFactory;
+
+class ExceptionTest extends TestCase
+{
+    public function testSaferpayErrorExceptionReturnsErrorResponse(): void
+    {
+        /** @var ErrorResponse $errorResponse */
+        $errorResponse = SerializerFactory::get()->deserialize(
+            '{"Behavior":"DO_NOT_RETRY","ErrorName":"VALIDATION_FAILED","ErrorMessage":"Invalid request"}',
+            ErrorResponse::class,
+            'json',
+        );
+
+        $exception = new SaferpayErrorException($errorResponse);
+
+        $this->assertSame($errorResponse, $exception->getErrorResponse());
+        $this->assertInstanceOf(SaferpayException::class, $exception);
+    }
+
+    public function testHttpRequestExceptionChainsPreviousException(): void
+    {
+        $previous = new \RuntimeException('connection failed');
+
+        $exception = new HttpRequestException($previous->getMessage(), 0, $previous);
+
+        $this->assertSame($previous, $exception->getPrevious());
+        $this->assertInstanceOf(SaferpayException::class, $exception);
+    }
+
+    public function testRequestWrapsTransportErrorsInHttpRequestException(): void
+    {
+        $previous = new \RuntimeException('connection failed');
+
+        $client = $this->createMock(Client::class);
+        $client->method('post')->willThrowException($previous);
+
+        $requestConfig = new RequestConfig('apiKey', 'apiSecret', 'customerId');
+        $requestConfig->setClient($client);
+
+        $request = new CancelRequest(
+            $requestConfig,
+            new TransactionReference(),
+        );
+
+        try {
+            $request->execute();
+            $this->fail('Expected HttpRequestException');
+        } catch (HttpRequestException $e) {
+            $this->assertSame($previous, $e->getPrevious());
+            $this->assertInstanceOf(SaferpayException::class, $e);
+        }
+    }
+}


### PR DESCRIPTION
Closes #124

- Make `SaferpayErrorException::getErrorResponse()` non-nullable
- Chain original exceptions in `HttpRequestException` via `$previous`
- Add `SaferpayException` marker interface implemented by both exception types

Made with [Cursor](https://cursor.com)