### PR TITLE
feat: Inject serializer via RequestConfig

### DIFF
--- a/lib/SaferpayJson/Request/Request.php
+++ b/lib/SaferpayJson/Request/Request.php
@@ -15,7 +15,6 @@ use Ticketpark\SaferpayJson\Request\Exception\HttpRequestException;
 use Ticketpark\SaferpayJson\Request\Exception\SaferpayErrorException;
 use Ticketpark\SaferpayJson\Response\ErrorResponse;
 use Ticketpark\SaferpayJson\Response\Response;
-use Ticketpark\SaferpayJson\SerializerFactory;
 
 abstract class Request
 {
@@ -131,6 +130,6 @@ abstract class Request
 
     private function getSerializer(): SerializerInterface
     {
-        return SerializerFactory::get();
+        return $this->requestConfig->getSerializer();
     }
 }

--- a/lib/SaferpayJson/Request/RequestConfig.php
+++ b/lib/SaferpayJson/Request/RequestConfig.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request;
 
 use GuzzleHttp\Client;
+use JMS\Serializer\SerializerInterface;
+use Ticketpark\SaferpayJson\SerializerFactory;
 
 final class RequestConfig
 {
@@ -20,6 +22,7 @@ final class RequestConfig
     private bool $test;
 
     private ?Client $client = null;
+    private ?SerializerInterface $serializer = null;
     private ?string $requestId = null;
     private int $retryIndicator = self::MIN_RETRY_INDICATOR;
 
@@ -76,6 +79,22 @@ final class RequestConfig
         }
 
         return $this->client;
+    }
+
+    public function setSerializer(SerializerInterface $serializer): self
+    {
+        $this->serializer = $serializer;
+
+        return $this;
+    }
+
+    public function getSerializer(): SerializerInterface
+    {
+        if (null === $this->serializer) {
+            return SerializerFactory::get();
+        }
+
+        return $this->serializer;
     }
 
     public function setRequestId(?string $requestId): self

--- a/tests/SaferpayJson/Tests/Request/RequestConfigTest.php
+++ b/tests/SaferpayJson/Tests/Request/RequestConfigTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Tests\Request;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use GuzzleHttp\Psr7\Utils as GuzzleUtils;
+use JMS\Serializer\SerializerInterface;
+use PHPUnit\Framework\TestCase;
+use Ticketpark\SaferpayJson\Request\Container\TransactionReference;
+use Ticketpark\SaferpayJson\Request\RequestConfig;
+use Ticketpark\SaferpayJson\Request\Transaction\CancelRequest;
+use Ticketpark\SaferpayJson\Response\Transaction\CancelResponse;
+use Ticketpark\SaferpayJson\SerializerFactory;
+
+class RequestConfigTest extends TestCase
+{
+    public function testGetSerializerDefaultsToFactory(): void
+    {
+        $config = new RequestConfig('apiKey', 'apiSecret', 'customerId');
+
+        $this->assertSame(SerializerFactory::get(), $config->getSerializer());
+    }
+
+    public function testSetSerializerReturnsInjectedInstance(): void
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+
+        $config = new RequestConfig('apiKey', 'apiSecret', 'customerId');
+
+        $this->assertSame($config, $config->setSerializer($serializer));
+        $this->assertSame($serializer, $config->getSerializer());
+    }
+
+    public function testRequestUsesInjectedSerializer(): void
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('serialize')
+            ->willReturn('{}');
+        $serializer->expects($this->once())
+            ->method('deserialize')
+            ->willReturn(new CancelResponse());
+
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('post')
+            ->willReturn(new GuzzleResponse(200, [], GuzzleUtils::streamFor('{}')));
+
+        $requestConfig = new RequestConfig('apiKey', 'apiSecret', 'customerId');
+        $requestConfig->setClient($client);
+        $requestConfig->setSerializer($serializer);
+
+        $request = new CancelRequest(
+            $requestConfig,
+            new TransactionReference(),
+        );
+
+        $response = $request->execute();
+
+        $this->assertInstanceOf(CancelResponse::class, $response);
+    }
+}


### PR DESCRIPTION
Closes #126

- Add optional `SerializerInterface` to `RequestConfig` via `setSerializer()` / `getSerializer()`, defaulting to `SerializerFactory::get()`
- Resolve serializer from `RequestConfig` in `Request` instead of calling `SerializerFactory` directly
- Add `RequestConfigTest` covering default, injection, and request wiring

Made with [Cursor](https://cursor.com)