### PR TITLE
ci: Run static analysis on PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           tools: composer
           coverage: none
 
@@ -77,9 +77,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-8.3-composer-${{ hashFiles('composer.json') }}
+          key: ${{ runner.os }}-php-8.5-composer-${{ hashFiles('composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-php-8.3-composer-
+            ${{ runner.os }}-php-8.5-composer-
             ${{ runner.os }}-composer-
 
       - name: Install dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,7 +172,7 @@ Request tests extend `CommonRequestTest`:
 - Call `doTestSuccessfulResponse(ResponseClass::class)` for the happy path
 - Error path and `RequestConfig` retry validation are inherited
 
-CI (`.github/workflows/tests.yml`) runs PHPUnit on PHP 7.4–8.5 (prefer-lowest and prefer-stable), plus PHPStan level 8, php-cs-fixer, and `composer validate`.
+CI (`.github/workflows/tests.yml`) runs PHPUnit on PHP 7.4–8.5 (prefer-lowest and prefer-stable). Static analysis (PHPStan level 8, php-cs-fixer, `composer validate`) runs on PHP 8.5.
 
 ## Common pitfalls
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "phpstan/phpstan": "^1.6",
-        "friendsofphp/php-cs-fixer": "^3.16",
+        "friendsofphp/php-cs-fixer": "^3.80",
         "rector/rector": "^1.1"
     },
     "autoload": {


### PR DESCRIPTION
- Run the static code analysis CI job (validate, lint, cs-check, PHPStan) on PHP 8.5 instead of 8.3
- Bump `friendsofphp/php-cs-fixer` to `^3.80` for PHP 8.5 compatibility

Made with [Cursor](https://cursor.com)