### PR TITLE
feat: Raise minimum PHP to 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['8.2', '8.3', '8.4', '8.5']
         stability: ['prefer-lowest', 'prefer-stable']
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,7 +11,7 @@ return (new PhpCsFixer\Config())
         '@Symfony' => true,
         'declare_strict_types' => true,
         'trailing_comma_in_multiline' => [
-            'elements' => ['arrays', 'arguments'],
+            'elements' => ['arrays', 'arguments', 'parameters'],
         ],
     ])
     ->setFinder($finder)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,8 @@ PHP library (`ticketpark/saferpay-json-api`) that wraps the [Saferpay JSON API](
 
 - **Namespace:** `Ticketpark\SaferpayJson`
 - **Autoload:** `lib/SaferpayJson/` (PSR-4)
-- **PHP:** 7.4–8.5
-- **Key dependencies:** `jms/serializer`, `psr/http-client`, `guzzlehttp/guzzle` (default HTTP client), `doctrine/annotations`
+- **PHP:** 8.2–8.5
+- **Key dependencies:** `jms/serializer`, `psr/http-client`, `guzzlehttp/guzzle` (default HTTP client)
 
 Check `lib/SaferpayJson/Request/Container/RequestHeader.php` and `README.md` for the current target API version.
 
@@ -54,14 +54,14 @@ Each endpoint is a `final class` extending `Request`:
 - `public const RESPONSE_CLASS = SomeResponse::class`
 - Constructor takes `RequestConfig` plus Saferpay-mandatory fields; calls `parent::__construct($requestConfig)`
 - `execute(): SomeResponse` delegates to `doExecute()` with a return type hint
-- Properties map to JSON via `@SerializedName("FieldName")` (PascalCase, matching Saferpay docs)
+- Properties map to JSON via `#[SerializedName('FieldName')]` attributes (PascalCase, matching Saferpay docs)
 - Enum-like API values get `public const` on the request class (e.g. `PAYMENT_METHOD_VISA`, `WALLET_APPLEPAY`)
 
 ### Containers
 
 **Request containers** (`lib/SaferpayJson/Request/Container/`):
 
-- `final class`, `@SerializedName` on every property
+- `final class`, `#[SerializedName]` on every property
 - Mandatory Saferpay fields → constructor parameters, **no setters** for constructor args
 - Optional fields → nullable properties with getters/setters returning `self`
 - Reuse existing containers when Saferpay reuses the same JSON structure (e.g. `ForeignRetailer` in both `Marketplace` and `MerchantFundDistributor`)
@@ -127,7 +127,7 @@ Stick to [.github/pull_request_template.md](.github/pull_request_template.md): `
 ```php
 final class ExampleContainer
 {
-    /** @SerializedName("FieldName") */
+    #[SerializedName('FieldName')]
     private ?string $field = null;
 
     public function getField(): ?string { ... }
@@ -142,7 +142,7 @@ Place under `Request/Container/`. Use sub-namespaces when Saferpay groups contai
 1. Add `*Request` in the appropriate `Request/` subdirectory.
 2. Add `*Response` in the matching `Response/` subdirectory extending `Response`.
 3. Add containers for any new JSON structures.
-4. Add `tests/SaferpayJson/Tests/Request/.../*RequestTest.php` extending `CommonRequestTest`.
+4. Add `tests/SaferpayJson/Tests/Request/.../*RequestTest.php` extending `CommonRequestTestCase`.
 5. Optionally add an `example/` script.
 
 ### Constants
@@ -166,13 +166,13 @@ composer cs-check
 composer cs-fix   # apply coding standard fixes
 ```
 
-Request tests extend `CommonRequestTest`:
+Request tests extend `CommonRequestTestCase`:
 
 - Implement `getInstance()` returning a configured request
 - Call `doTestSuccessfulResponse(ResponseClass::class)` for the happy path
 - Error path and `RequestConfig` retry validation are inherited
 
-CI (`.github/workflows/tests.yml`) runs PHPUnit on PHP 7.4–8.5 (prefer-lowest and prefer-stable). Static analysis (PHPStan level 8, php-cs-fixer, `composer validate`) runs on PHP 8.5.
+CI (`.github/workflows/tests.yml`) runs PHPUnit on PHP 8.2–8.5 (prefer-lowest and prefer-stable). Static analysis (PHPStan level 8, php-cs-fixer, `composer validate`) runs on PHP 8.5.
 
 ## Common pitfalls
 

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,16 @@
         }
     ],
     "require": {
-        "php": "~7.4|~8.0.0|~8.1.0|~8.2.0|~8.3.0|~8.4.0|~8.5.0",
-        "doctrine/annotations": "^1.11|^2.0",
+        "php": "^8.2",
         "jms/serializer": "^3.16",
         "psr/http-client": "^1.0",
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
-        "phpstan/phpstan": "^1.6",
+        "phpunit/phpunit": "^11.0",
+        "phpstan/phpstan": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.80",
-        "rector/rector": "^1.1"
+        "rector/rector": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/lib/SaferpayJson/Request/Container/A2a.php
+++ b/lib/SaferpayJson/Request/Container/A2a.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class A2a
 {
-    /**
-     * @SerializedName("AccountHolderName")
-     */
+    #[SerializedName('AccountHolderName')]
     private string $accountHolderName;
 
     public function __construct(string $accountHolderName)

--- a/lib/SaferpayJson/Request/Container/Address.php
+++ b/lib/SaferpayJson/Request/Container/Address.php
@@ -13,74 +13,46 @@ final class Address
     public const GENDER_DIVERSE = 'DIVERSE';
     public const GENDER_COMPANY = 'COMPANY';
 
-    /**
-     * @SerializedName("FirstName")
-     */
+    #[SerializedName('FirstName')]
     private ?string $firstName = null;
 
-    /**
-     * @SerializedName("LastName")
-     */
+    #[SerializedName('LastName')]
     private ?string $lastName = null;
 
-    /**
-     * @SerializedName("Company")
-     */
+    #[SerializedName('Company')]
     private ?string $company = null;
 
-    /**
-     * @SerializedName("Gender")
-     */
+    #[SerializedName('Gender')]
     private ?string $gender = null;
 
-    /**
-     * @SerializedName("Street")
-     */
+    #[SerializedName('Street')]
     private ?string $street = null;
 
-    /**
-     * @SerializedName("Zip")
-     */
+    #[SerializedName('Zip')]
     private ?string $zip = null;
 
-    /**
-     * @SerializedName("City")
-     */
+    #[SerializedName('City')]
     private ?string $city = null;
 
-    /**
-     * @SerializedName("CountryCode")
-     */
+    #[SerializedName('CountryCode')]
     private ?string $countryCode = null;
 
-    /**
-     * @SerializedName("Email")
-     */
+    #[SerializedName('Email')]
     private ?string $email = null;
 
-    /**
-     * @SerializedName("DateOfBirth")
-     */
+    #[SerializedName('DateOfBirth')]
     private ?\DateTime $dateOfBirth = null;
 
-    /**
-     * @SerializedName("Street2")
-     */
+    #[SerializedName('Street2')]
     private ?string $street2 = null;
 
-    /**
-     * @SerializedName("CountrySubdivisionCode")
-     */
+    #[SerializedName('CountrySubdivisionCode')]
     private ?string $countrySubdivisionCode = null;
 
-    /**
-     * @SerializedName("Phone")
-     */
+    #[SerializedName('Phone')]
     private ?string $phone = null;
 
-    /**
-     * @SerializedName("VatNumber")
-     */
+    #[SerializedName('VatNumber')]
     private ?string $vatNumber = null;
 
     public function getFirstName(): ?string

--- a/lib/SaferpayJson/Request/Container/AddressForm.php
+++ b/lib/SaferpayJson/Request/Container/AddressForm.php
@@ -24,16 +24,10 @@ final class AddressForm
     public const ADDRESS_SOURCE_SAFERPAY = 'SAFERPAY';
     public const ADDRESS_SOURCE_PREFER_PAYMENTMETHOD = 'PREFER_PAYMENTMETHOD';
 
-    /**
-     * @SerializedName("AddressSource")
-     */
+    #[SerializedName('AddressSource')]
     private string $addressSource;
 
-    /**
-     * @var array<string>|null
-     *
-     * @SerializedName("MandatoryFields")
-     */
+    #[SerializedName('MandatoryFields')]
     private ?array $mandatoryFields = [];
 
     public function __construct(string $addressSource)

--- a/lib/SaferpayJson/Request/Container/Alias.php
+++ b/lib/SaferpayJson/Request/Container/Alias.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Alias
 {
-    /**
-     * @SerializedName("Id")
-     */
+    #[SerializedName('Id')]
     private string $id;
 
-    /**
-     * @SerializedName("VerificationCode")
-     */
+    #[SerializedName('VerificationCode')]
     private ?string $verificationCode = null;
 
     public function __construct(string $id)

--- a/lib/SaferpayJson/Request/Container/Amount.php
+++ b/lib/SaferpayJson/Request/Container/Amount.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Amount
 {
-    /**
-     * @SerializedName("Value")
-     */
+    #[SerializedName('Value')]
     private int $value;
 
-    /**
-     * @SerializedName("CurrencyCode")
-     */
+    #[SerializedName('CurrencyCode')]
     private string $currencyCode;
 
     public function __construct(int $value, string $currencyCode)

--- a/lib/SaferpayJson/Request/Container/ApplePay.php
+++ b/lib/SaferpayJson/Request/Container/ApplePay.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class ApplePay
 {
-    /**
-     * @SerializedName("PaymentToken")
-     */
+    #[SerializedName('PaymentToken')]
     private string $paymentToken;
 
     public function __construct(string $paymentToken)

--- a/lib/SaferpayJson/Request/Container/Attachment.php
+++ b/lib/SaferpayJson/Request/Container/Attachment.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Attachment
 {
-    /**
-     * @SerializedName("ContentType")
-     */
+    #[SerializedName('ContentType')]
     private string $contentType;
 
-    /**
-     * @SerializedName("Body")
-     */
+    #[SerializedName('Body')]
     private string $body;
 
     public function __construct(string $contentType, string $body)

--- a/lib/SaferpayJson/Request/Container/Authentication.php
+++ b/lib/SaferpayJson/Request/Container/Authentication.php
@@ -15,19 +15,13 @@ final class Authentication
     public const THREEDSCHALLENGE_FORCE = 'FORCE';
     public const THREEDSCHALLENGE_AVOID = 'AVOID';
 
-    /**
-     * @SerializedName("Exemption")
-     */
+    #[SerializedName('Exemption')]
     private ?string $exemption = null;
 
-    /**
-     * @SerializedName("ThreeDsChallenge")
-     */
+    #[SerializedName('ThreeDsChallenge')]
     private ?string $threeDsChallenge = null;
 
-    /**
-     * @SerializedName("ExternalThreeDS")
-     */
+    #[SerializedName('ExternalThreeDS')]
     private ?ExternalThreeDS $externalThreeDS = null;
 
     public function getExemption(): ?string

--- a/lib/SaferpayJson/Request/Container/BankAccount.php
+++ b/lib/SaferpayJson/Request/Container/BankAccount.php
@@ -8,24 +8,16 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class BankAccount
 {
-    /**
-     * @SerializedName("Iban")
-     */
+    #[SerializedName('Iban')]
     private string $iban;
 
-    /**
-     * @SerializedName("HolderName")
-     */
+    #[SerializedName('HolderName')]
     private ?string $holderName = null;
 
-    /**
-     * @SerializedName("BIC")
-     */
+    #[SerializedName('BIC')]
     private ?string $bic = null;
 
-    /**
-     * @SerializedName("BankName")
-     */
+    #[SerializedName('BankName')]
     private ?string $bankName = null;
 
     public function __construct(string $iban)

--- a/lib/SaferpayJson/Request/Container/Billpay.php
+++ b/lib/SaferpayJson/Request/Container/Billpay.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Billpay
 {
-    /**
-     * @SerializedName("DelayInDays")
-     */
+    #[SerializedName('DelayInDays')]
     private ?int $delayInDays = null;
 
     public function getDelayInDays(): ?int

--- a/lib/SaferpayJson/Request/Container/Brand.php
+++ b/lib/SaferpayJson/Request/Container/Brand.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Brand
 {
-    /**
-     * @SerializedName("PaymentMethod")
-     */
+    #[SerializedName('PaymentMethod')]
     private ?string $paymentMethod = null;
 
-    /**
-     * @SerializedName("Name")
-     */
+    #[SerializedName('Name')]
     private ?string $name = null;
 
     public function getPaymentMethod(): ?string

--- a/lib/SaferpayJson/Request/Container/CaptureReference.php
+++ b/lib/SaferpayJson/Request/Container/CaptureReference.php
@@ -8,24 +8,16 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class CaptureReference
 {
-    /**
-     * @SerializedName("CaptureId")
-     */
+    #[SerializedName('CaptureId')]
     private ?string $captureId = null;
 
-    /**
-     * @SerializedName("TransactionId")
-     */
+    #[SerializedName('TransactionId')]
     private ?string $transactionId = null;
 
-    /**
-     * @SerializedName("OrderId")
-     */
+    #[SerializedName('OrderId')]
     private ?string $orderId = null;
 
-    /**
-     * @SerializedName("OrderPartId")
-     */
+    #[SerializedName('OrderPartId')]
     private ?string $orderPartId = null;
 
     public function getCaptureId(): ?string

--- a/lib/SaferpayJson/Request/Container/Card.php
+++ b/lib/SaferpayJson/Request/Container/Card.php
@@ -8,29 +8,19 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Card
 {
-    /**
-     * @SerializedName("Number")
-     */
+    #[SerializedName('Number')]
     private ?string $number = null;
 
-    /**
-     * @SerializedName("ExpYear")
-     */
+    #[SerializedName('ExpYear')]
     private ?int $expYear = null;
 
-    /**
-     * @SerializedName("ExpMonth")
-     */
+    #[SerializedName('ExpMonth')]
     private ?int $expMonth = null;
 
-    /**
-     * @SerializedName("HolderName")
-     */
+    #[SerializedName('HolderName')]
     private ?string $holderName = null;
 
-    /**
-     * @SerializedName("CountryCode")
-     */
+    #[SerializedName('CountryCode')]
     private ?string $countryCode = null;
 
     public function getNumber(): ?string

--- a/lib/SaferpayJson/Request/Container/CardForm.php
+++ b/lib/SaferpayJson/Request/Container/CardForm.php
@@ -11,9 +11,7 @@ final class CardForm
     public const HOLDER_NAME_NONE = 'NONE';
     public const HOLDER_NAME_MANDATORY = 'MANDATORY';
 
-    /**
-     * @SerializedName("HolderName")
-     */
+    #[SerializedName('HolderName')]
     private ?string $holderName = null;
 
     public function getHolderName(): ?string

--- a/lib/SaferpayJson/Request/Container/Check.php
+++ b/lib/SaferpayJson/Request/Container/Check.php
@@ -11,14 +11,10 @@ final class Check
     public const TYPE_ONLINE = 'ONLINE';
     public const TYPE_ONLINE_STRONG = 'ONLINE_STRONG';
 
-    /**
-     * @SerializedName("Type")
-     */
+    #[SerializedName('Type')]
     private ?string $type = null;
 
-    /**
-     * @SerializedName("TerminalId")
-     */
+    #[SerializedName('TerminalId')]
     private ?string $terminalId = null;
 
     public function getType(): ?string

--- a/lib/SaferpayJson/Request/Container/ChosenPlan.php
+++ b/lib/SaferpayJson/Request/Container/ChosenPlan.php
@@ -8,39 +8,25 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class ChosenPlan
 {
-    /**
-     * @SerializedName("NumberOfInstallments")
-     */
+    #[SerializedName('NumberOfInstallments')]
     private int $numberOfInstallments;
 
-    /**
-     * @SerializedName("InterestRate")
-     */
+    #[SerializedName('InterestRate')]
     private ?string $interestRate = null;
 
-    /**
-     * @SerializedName("InstallmentFee")
-     */
+    #[SerializedName('InstallmentFee')]
     private ?Amount $installmentFee = null;
 
-    /**
-     * @SerializedName("AnnualPercentageRate")
-     */
+    #[SerializedName('AnnualPercentageRate')]
     private ?string $annualPercentageRate = null;
 
-    /**
-     * @SerializedName("FirstInstallmentAmount")
-     */
+    #[SerializedName('FirstInstallmentAmount')]
     private ?Amount $firstInstallmentAmount = null;
 
-    /**
-     * @SerializedName("SubsequentInstallmentAmount")
-     */
+    #[SerializedName('SubsequentInstallmentAmount')]
     private ?Amount $subsequentInstallmentAmount = null;
 
-    /**
-     * @SerializedName("TotalAmountDue")
-     */
+    #[SerializedName('TotalAmountDue')]
     private ?Amount $totalAmountDue = null;
 
     public function __construct(int $numberOfInstallments)

--- a/lib/SaferpayJson/Request/Container/ClientInfo.php
+++ b/lib/SaferpayJson/Request/Container/ClientInfo.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class ClientInfo
 {
-    /**
-     * @SerializedName("ShopInfo")
-     */
+    #[SerializedName('ShopInfo')]
     private ?string $shopInfo = null;
 
-    /**
-     * @SerializedName("OsInfo")
-     */
+    #[SerializedName('OsInfo')]
     private ?string $osInfo = null;
 
     public function getShopInfo(): ?string

--- a/lib/SaferpayJson/Request/Container/DccReference.php
+++ b/lib/SaferpayJson/Request/Container/DccReference.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class DccReference
 {
-    /**
-     * @SerializedName("SelectedCurrencyCode")
-     */
+    #[SerializedName('SelectedCurrencyCode')]
     private string $selectedCurrencyCode;
 
-    /**
-     * @SerializedName("Token")
-     */
+    #[SerializedName('Token')]
     private string $token;
 
     public function __construct(string $selectedCurrencyCode, string $token)

--- a/lib/SaferpayJson/Request/Container/ExternalThreeDS.php
+++ b/lib/SaferpayJson/Request/Container/ExternalThreeDS.php
@@ -22,54 +22,34 @@ final class ExternalThreeDS
     public const TRANS_STATUS_U = 'U';
     public const TRANS_STATUS_I = 'I';
 
-    /**
-     * @SerializedName("AcsTransId")
-     */
+    #[SerializedName('AcsTransId')]
     private string $acsTransId;
 
-    /**
-     * @SerializedName("AuthenticationMode")
-     */
+    #[SerializedName('AuthenticationMode')]
     private ?string $authenticationMode = null;
 
-    /**
-     * @SerializedName("AuthenticationTime")
-     */
+    #[SerializedName('AuthenticationTime')]
     private string $authenticationTime;
 
-    /**
-     * @SerializedName("AuthenticationValue")
-     */
+    #[SerializedName('AuthenticationValue')]
     private string $authenticationValue;
 
-    /**
-     * @SerializedName("DsTransId")
-     */
+    #[SerializedName('DsTransId')]
     private string $dsTransId;
 
-    /**
-     * @SerializedName("Eci")
-     */
+    #[SerializedName('Eci')]
     private string $eci;
 
-    /**
-     * @SerializedName("Scheme")
-     */
+    #[SerializedName('Scheme')]
     private string $scheme;
 
-    /**
-     * @SerializedName("ThreeDsFullVersion")
-     */
+    #[SerializedName('ThreeDsFullVersion')]
     private string $threeDsFullVersion;
 
-    /**
-     * @SerializedName("ThreeDSServerTransId")
-     */
+    #[SerializedName('ThreeDSServerTransId')]
     private string $threeDSServerTransId;
 
-    /**
-     * @SerializedName("TransStatus")
-     */
+    #[SerializedName('TransStatus')]
     private string $transStatus;
 
     public function __construct(
@@ -81,7 +61,7 @@ final class ExternalThreeDS
         string $scheme,
         string $threeDsFullVersion,
         string $threeDSServerTransId,
-        string $transStatus
+        string $transStatus,
     ) {
         $this->acsTransId = $acsTransId;
         $this->authenticationTime = $authenticationTime;

--- a/lib/SaferpayJson/Request/Container/ForeignRetailer.php
+++ b/lib/SaferpayJson/Request/Container/ForeignRetailer.php
@@ -8,29 +8,19 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class ForeignRetailer
 {
-    /**
-     * @SerializedName("City")
-     */
+    #[SerializedName('City')]
     private ?string $city = null;
 
-    /**
-     * @SerializedName("CountryCode")
-     */
+    #[SerializedName('CountryCode')]
     private string $countryCode;
 
-    /**
-     * @SerializedName("Name")
-     */
+    #[SerializedName('Name')]
     private ?string $name = null;
 
-    /**
-     * @SerializedName("Street")
-     */
+    #[SerializedName('Street')]
     private ?string $street = null;
 
-    /**
-     * @SerializedName("Zip")
-     */
+    #[SerializedName('Zip')]
     private ?string $zip = null;
 
     public function __construct(string $countryCode)

--- a/lib/SaferpayJson/Request/Container/GooglePay.php
+++ b/lib/SaferpayJson/Request/Container/GooglePay.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class GooglePay
 {
-    /**
-     * @SerializedName("PaymentToken")
-     */
+    #[SerializedName('PaymentToken')]
     private string $paymentToken;
 
     public function __construct(string $paymentToken)

--- a/lib/SaferpayJson/Request/Container/Ideal.php
+++ b/lib/SaferpayJson/Request/Container/Ideal.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Ideal
 {
-    /**
-     * @SerializedName("IssuerId")
-     */
+    #[SerializedName('IssuerId')]
     private string $issuerId;
 
     public function __construct(string $issuerId)

--- a/lib/SaferpayJson/Request/Container/Installment.php
+++ b/lib/SaferpayJson/Request/Container/Installment.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Installment
 {
-    /**
-     * @SerializedName("Initial")
-     */
+    #[SerializedName('Initial')]
     private bool $initial;
 
     public function __construct(bool $initial)

--- a/lib/SaferpayJson/Request/Container/IssuerReference.php
+++ b/lib/SaferpayJson/Request/Container/IssuerReference.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class IssuerReference
 {
-    /**
-     * @SerializedName("TransactionStamp")
-     */
+    #[SerializedName('TransactionStamp')]
     private string $transactionStamp;
 
-    /**
-     * @SerializedName("SettlementDate")
-     */
+    #[SerializedName('SettlementDate')]
     private ?string $settlementDate = null;
 
     public function __construct(string $transactionStamp)

--- a/lib/SaferpayJson/Request/Container/Klarna.php
+++ b/lib/SaferpayJson/Request/Container/Klarna.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Klarna
 {
-    /**
-     * @SerializedName("Attachment")
-     */
+    #[SerializedName('Attachment')]
     private Attachment $attachment;
 
     public function __construct(Attachment $attachment)

--- a/lib/SaferpayJson/Request/Container/Marketplace.php
+++ b/lib/SaferpayJson/Request/Container/Marketplace.php
@@ -8,24 +8,16 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Marketplace
 {
-    /**
-     * @SerializedName("SubmerchantId")
-     */
+    #[SerializedName('SubmerchantId')]
     private string $submerchantId;
 
-    /**
-     * @SerializedName("Fee")
-     */
+    #[SerializedName('Fee')]
     private ?Amount $fee = null;
 
-    /**
-     * @SerializedName("FeeRefund")
-     */
+    #[SerializedName('FeeRefund')]
     private ?Amount $feeRefund = null;
 
-    /**
-     * @SerializedName("ForeignRetailer")
-     */
+    #[SerializedName('ForeignRetailer')]
     private ?ForeignRetailer $foreignRetailer = null;
 
     public function __construct(string $submerchantId)

--- a/lib/SaferpayJson/Request/Container/MastercardIssuerInstallments.php
+++ b/lib/SaferpayJson/Request/Container/MastercardIssuerInstallments.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class MastercardIssuerInstallments
 {
-    /**
-     * @SerializedName("ChosenPlan")
-     */
+    #[SerializedName('ChosenPlan')]
     private ?ChosenPlan $chosenPlan = null;
 
     public function getChosenPlan(): ?ChosenPlan

--- a/lib/SaferpayJson/Request/Container/MerchantFundDistributor.php
+++ b/lib/SaferpayJson/Request/Container/MerchantFundDistributor.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class MerchantFundDistributor
 {
-    /**
-     * @SerializedName("ForeignRetailer")
-     */
+    #[SerializedName('ForeignRetailer')]
     private ?ForeignRetailer $foreignRetailer = null;
 
     public function getForeignRetailer(): ?ForeignRetailer

--- a/lib/SaferpayJson/Request/Container/Notification.php
+++ b/lib/SaferpayJson/Request/Container/Notification.php
@@ -8,31 +8,19 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Notification
 {
-    /**
-     * @var array<string>
-     *
-     * @SerializedName("MerchantEmails")
-     */
+    #[SerializedName('MerchantEmails')]
     private ?array $merchantEmails = [];
 
-    /**
-     * @SerializedName("PayerEmail")
-     */
+    #[SerializedName('PayerEmail')]
     private ?string $payerEmail = null;
 
-    /**
-     * @SerializedName("PayerDccReceiptEmail")
-     */
+    #[SerializedName('PayerDccReceiptEmail')]
     private ?string $payerDccReceiptEmail = null;
 
-    /**
-     * @SerializedName("SuccessNotifyUrl")
-     */
+    #[SerializedName('SuccessNotifyUrl')]
     private ?string $successNotifyUrl = null;
 
-    /**
-     * @SerializedName("FailNotifyUrl")
-     */
+    #[SerializedName('FailNotifyUrl')]
     private ?string $failNotifyUrl = null;
 
     public function getMerchantEmails(): ?array

--- a/lib/SaferpayJson/Request/Container/Options.php
+++ b/lib/SaferpayJson/Request/Container/Options.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Options
 {
-    /**
-     * @SerializedName("PreAuth")
-     */
+    #[SerializedName('PreAuth')]
     private ?bool $preAuth = null;
 
-    /**
-     * @SerializedName("AllowPartialAuthorization")
-     */
+    #[SerializedName('AllowPartialAuthorization')]
     private ?bool $allowPartialAuthorization = null;
 
     public function isPreAuth(): ?bool

--- a/lib/SaferpayJson/Request/Container/Order.php
+++ b/lib/SaferpayJson/Request/Container/Order.php
@@ -8,11 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Order
 {
-    /**
-     * @var array<OrderItem>
-     *
-     * @SerializedName("Items")
-     */
+    #[SerializedName('Items')]
     private ?array $items = [];
 
     public function getItems(): ?array

--- a/lib/SaferpayJson/Request/Container/OrderItem.php
+++ b/lib/SaferpayJson/Request/Container/OrderItem.php
@@ -17,74 +17,46 @@ final class OrderItem
     public const TYPE_SALESTAX = 'SALESTAX';
     public const TYPE_SURCHARGE = 'SURCHARGE';
 
-    /**
-     * @SerializedName("Type")
-     */
+    #[SerializedName('Type')]
     private ?string $type = null;
 
-    /**
-     * @SerializedName("Id")
-     */
+    #[SerializedName('Id')]
     private ?string $id = null;
 
-    /**
-     * @SerializedName("VariantId")
-     */
+    #[SerializedName('VariantId')]
     private ?string $variantId = null;
 
-    /**
-     * @SerializedName("Name")
-     */
+    #[SerializedName('Name')]
     private ?string $name = null;
 
-    /**
-     * @SerializedName("CategoryName")
-     */
+    #[SerializedName('CategoryName')]
     private ?string $categoryName = null;
 
-    /**
-     * @SerializedName("Description")
-     */
+    #[SerializedName('Description')]
     private ?string $description = null;
 
-    /**
-     * @SerializedName("Quantity")
-     */
+    #[SerializedName('Quantity')]
     private ?string $quantity = null;
 
-    /**
-     * @SerializedName("UnitPrice")
-     */
+    #[SerializedName('UnitPrice')]
     private ?string $unitPrice = null;
 
-    /**
-     * @SerializedName("IsPreOrder")
-     */
+    #[SerializedName('IsPreOrder')]
     private ?string $isPreOrder = null;
 
-    /**
-     * @SerializedName("TaxRate")
-     */
+    #[SerializedName('TaxRate')]
     private ?string $taxRate = null;
 
-    /**
-     * @SerializedName("TaxAmount")
-     */
+    #[SerializedName('TaxAmount')]
     private ?string $taxAmount = null;
 
-    /**
-     * @SerializedName("DiscountAmount")
-     */
+    #[SerializedName('DiscountAmount')]
     private ?string $discountAmount = null;
 
-    /**
-     * @SerializedName("ProductUrl")
-     */
+    #[SerializedName('ProductUrl')]
     private ?string $productUrl = null;
 
-    /**
-     * @SerializedName("ImageUrl")
-     */
+    #[SerializedName('ImageUrl')]
     private ?string $imageUrl = null;
 
     public function getType(): ?string

--- a/lib/SaferpayJson/Request/Container/Payer.php
+++ b/lib/SaferpayJson/Request/Container/Payer.php
@@ -8,28 +8,18 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Payer
 {
-    /**
-     * @SerializedName("Id")
-     */
+    #[SerializedName('Id')]
     private ?string $id = null;
 
-    /**
-     * @SerializedName("IpAddress")
-     */
+    #[SerializedName('IpAddress')]
     private ?string $ipAddress = null;
-    /**
-     * @SerializedName("LanguageCode")
-     */
+    #[SerializedName('LanguageCode')]
     private ?string $languageCode = null;
 
-    /**
-     * @SerializedName("DeliveryAddress")
-     */
+    #[SerializedName('DeliveryAddress')]
     private ?Address $deliveryAddress = null;
 
-    /**
-     * @SerializedName("BillingAddress")
-     */
+    #[SerializedName('BillingAddress')]
     private ?Address $billingAddress = null;
 
     public function getId(): ?string

--- a/lib/SaferpayJson/Request/Container/PayerProfile.php
+++ b/lib/SaferpayJson/Request/Container/PayerProfile.php
@@ -14,80 +14,49 @@ final class PayerProfile
     public const GENDER_DIVERSE = 'DIVERSE';
     public const GENDER_COMPANY = 'COMPANY';
 
-    /**
-     * @SerializedName("HasAccount")
-     */
+    #[SerializedName('HasAccount')]
     private ?bool $hasAccount = null;
 
-    /**
-     * @SerializedName("HasPassword")
-     */
+    #[SerializedName('HasPassword')]
     private ?bool $hasPassword = null;
 
-    /**
-     * @SerializedName("PasswordForgotten")
-     */
+    #[SerializedName('PasswordForgotten')]
     private ?bool $passwordForgotten = null;
 
-    /**
-     * @SerializedName("FirstName")
-     */
+    #[SerializedName('FirstName')]
     private ?string $firstName = null;
 
-    /**
-     * @SerializedName("LastName")
-     */
+    #[SerializedName('LastName')]
     private ?string $lastName = null;
 
-    /**
-     * @SerializedName("Company")
-     */
+    #[SerializedName('Company')]
     private ?string $company = null;
 
-    /**
-     * @SerializedName("DateOfBirth")
-     */
+    #[SerializedName('DateOfBirth')]
     private ?string $dateOfBirth = null;
 
-    /**
-     * @SerializedName("LastLoginDate")
-     *
-     * @Type("DateTime<'Y-m-d\TH:i:s.uT'>")
-     */
+    #[SerializedName('LastLoginDate')]
+    #[Type("DateTime<'Y-m-d\TH:i:s.uT'>")]
     private ?\DateTime $lastLoginDate = null;
 
-    /**
-     * @SerializedName("Gender")
-     */
+    #[SerializedName('Gender')]
     private ?string $gender = null;
 
-    /**
-     * @SerializedName("CreationDate")
-     *
-     * @Type("DateTime<'Y-m-d\TH:i:s.uT'>")
-     */
+    #[SerializedName('CreationDate')]
+    #[Type("DateTime<'Y-m-d\TH:i:s.uT'>")]
     private ?\DateTime $creationDate = null;
 
-    /**
-     * @SerializedName("PasswordLastChangeDate")
-     *
-     * @Type("DateTime<'Y-m-d\TH:i:s.uT'>")
-     */
+    #[SerializedName('PasswordLastChangeDate')]
+    #[Type("DateTime<'Y-m-d\TH:i:s.uT'>")]
     private ?\DateTime $passwordLastChangeDate = null;
 
-    /**
-     * @SerializedName("Email")
-     */
+    #[SerializedName('Email')]
     private ?string $email = null;
 
-    /**
-     * @SerializedName("SecondaryEmail")
-     */
+    #[SerializedName('SecondaryEmail')]
     private ?string $secondaryEmail = null;
 
-    /**
-     * @SerializedName("Phone")
-     */
+    #[SerializedName('Phone')]
     private ?Phone $phone = null;
 
     public function getHasAccount(): ?bool

--- a/lib/SaferpayJson/Request/Container/Payment.php
+++ b/lib/SaferpayJson/Request/Container/Payment.php
@@ -8,44 +8,28 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Payment
 {
-    /**
-     * @SerializedName("Amount")
-     */
+    #[SerializedName('Amount')]
     private Amount $amount;
 
-    /**
-     * @SerializedName("OrderId")
-     */
+    #[SerializedName('OrderId')]
     private ?string $orderId = null;
 
-    /**
-     * @SerializedName("PayerNote")
-     */
+    #[SerializedName('PayerNote')]
     private ?string $payerNote = null;
 
-    /**
-     * @SerializedName("Description")
-     */
+    #[SerializedName('Description')]
     private ?string $description = null;
 
-    /**
-     * @SerializedName("MandateId")
-     */
+    #[SerializedName('MandateId')]
     private ?string $mandateId = null;
 
-    /**
-     * @SerializedName("Options")
-     */
+    #[SerializedName('Options')]
     private ?Options $options = null;
 
-    /**
-     * @SerializedName("Recurring")
-     */
+    #[SerializedName('Recurring')]
     private ?Recurring $recurring = null;
 
-    /**
-     * @SerializedName("Installment")
-     */
+    #[SerializedName('Installment')]
     private ?Installment $installment = null;
 
     public function __construct(Amount $amount)

--- a/lib/SaferpayJson/Request/Container/PaymentMeans.php
+++ b/lib/SaferpayJson/Request/Container/PaymentMeans.php
@@ -8,59 +8,37 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class PaymentMeans
 {
-    /**
-     * @SerializedName("Brand")
-     */
+    #[SerializedName('Brand')]
     private ?Brand $brand = null;
 
-    /**
-     * @SerializedName("DisplayText")
-     */
+    #[SerializedName('DisplayText')]
     private ?string $displayText = null;
 
-    /**
-     * @SerializedName("Wallet")
-     */
+    #[SerializedName('Wallet')]
     private ?string $wallet = null;
 
-    /**
-     * @SerializedName("Card")
-     */
+    #[SerializedName('Card')]
     private ?Card $card = null;
 
-    /**
-     * @SerializedName("BankAccount")
-     */
+    #[SerializedName('BankAccount')]
     private ?BankAccount $bankAccount = null;
 
-    /**
-     * @SerializedName("Twint")
-     */
+    #[SerializedName('Twint')]
     private ?Twint $twint = null;
 
-    /**
-     * @SerializedName("SaferpayFields")
-     */
+    #[SerializedName('SaferpayFields')]
     private ?SaferpayFields $saferpayFields = null;
 
-    /**
-     * @SerializedName("Alias")
-     */
+    #[SerializedName('Alias')]
     private ?Alias $alias = null;
 
-    /**
-     * @SerializedName("SchemeToken")
-     */
+    #[SerializedName('SchemeToken')]
     private ?SchemeToken $schemeToken = null;
 
-    /**
-     * @SerializedName("ApplePay")
-     */
+    #[SerializedName('ApplePay')]
     private ?ApplePay $applePay = null;
 
-    /**
-     * @SerializedName("GooglePay")
-     */
+    #[SerializedName('GooglePay')]
     private ?GooglePay $googlePay = null;
 
     public function getBrand(): ?Brand

--- a/lib/SaferpayJson/Request/Container/PaymentMethodsOptions.php
+++ b/lib/SaferpayJson/Request/Container/PaymentMethodsOptions.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class PaymentMethodsOptions
 {
-    /**
-     * @SerializedName("Klarna")
-     */
+    #[SerializedName('Klarna')]
     private ?Klarna $klarna = null;
 
     public function getKlarna(): ?Klarna

--- a/lib/SaferpayJson/Request/Container/PendingNotification.php
+++ b/lib/SaferpayJson/Request/Container/PendingNotification.php
@@ -8,16 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class PendingNotification
 {
-    /**
-     * @var array<string>
-     *
-     * @SerializedName("MerchantEmails")
-     */
+    #[SerializedName('MerchantEmails')]
     private ?array $merchantEmails = [];
 
-    /**
-     * @SerializedName("NotifyUrl")
-     */
+    #[SerializedName('NotifyUrl')]
     private ?string $notifyUrl = null;
 
     public function getMerchantEmails(): ?array

--- a/lib/SaferpayJson/Request/Container/Phone.php
+++ b/lib/SaferpayJson/Request/Container/Phone.php
@@ -8,19 +8,13 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Phone
 {
-    /**
-     * @SerializedName("Main")
-     */
+    #[SerializedName('Main')]
     private ?string $main = null;
 
-    /**
-     * @SerializedName("Mobile")
-     */
+    #[SerializedName('Mobile')]
     private ?string $mobile = null;
 
-    /**
-     * @SerializedName("Work")
-     */
+    #[SerializedName('Work')]
     private ?string $work = null;
 
     public function getMain(): ?string

--- a/lib/SaferpayJson/Request/Container/Recurring.php
+++ b/lib/SaferpayJson/Request/Container/Recurring.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Recurring
 {
-    /**
-     * @SerializedName("Initial")
-     */
+    #[SerializedName('Initial')]
     private bool $initial;
 
     public function __construct(bool $initial = true)

--- a/lib/SaferpayJson/Request/Container/RedirectNotifyUrls.php
+++ b/lib/SaferpayJson/Request/Container/RedirectNotifyUrls.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class RedirectNotifyUrls
 {
-    /**
-     * @SerializedName("Success")
-     */
+    #[SerializedName('Success')]
     private string $success;
 
-    /**
-     * @SerializedName("Fail")
-     */
+    #[SerializedName('Fail')]
     private string $fail;
 
     public function __construct(string $success, string $fail)

--- a/lib/SaferpayJson/Request/Container/Refund.php
+++ b/lib/SaferpayJson/Request/Container/Refund.php
@@ -8,29 +8,19 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Refund
 {
-    /**
-     * @SerializedName("Amount")
-     */
+    #[SerializedName('Amount')]
     private ?Amount $amount;
 
-    /**
-     * @SerializedName("OrderId")
-     */
+    #[SerializedName('OrderId')]
     private ?string $orderId = null;
 
-    /**
-     * @SerializedName("Description")
-     */
+    #[SerializedName('Description')]
     private ?string $description = null;
 
-    /**
-     * @SerializedName("PayerNote")
-     */
+    #[SerializedName('PayerNote')]
     private ?string $payerNote = null;
 
-    /**
-     * @SerializedName("RestrictRefundAmountToCapturedAmount")
-     */
+    #[SerializedName('RestrictRefundAmountToCapturedAmount')]
     private ?bool $restrictRefundAmountToCapturedAmount = null;
 
     public function __construct(?Amount $amount)

--- a/lib/SaferpayJson/Request/Container/RegisterAlias.php
+++ b/lib/SaferpayJson/Request/Container/RegisterAlias.php
@@ -12,19 +12,13 @@ final class RegisterAlias
     public const ID_GENERATOR_RANDOM = 'RANDOM';
     public const ID_GENERATOR_RANDOM_UNIQUE = 'RANDOM_UNIQUE';
 
-    /**
-     * @SerializedName("IdGenerator")
-     */
+    #[SerializedName('IdGenerator')]
     private string $idGenerator;
 
-    /**
-     * @SerializedName("Id")
-     */
+    #[SerializedName('Id')]
     private ?string $id = null;
 
-    /**
-     * @SerializedName("Lifetime")
-     */
+    #[SerializedName('Lifetime')]
     private ?int $lifetime = null;
 
     public function __construct(string $idGenerator)

--- a/lib/SaferpayJson/Request/Container/RequestHeader.php
+++ b/lib/SaferpayJson/Request/Container/RequestHeader.php
@@ -9,35 +9,25 @@ use Ticketpark\SaferpayJson\Request\RequestConfig;
 
 final class RequestHeader
 {
-    /**
-     * @SerializedName("SpecVersion")
-     */
+    #[SerializedName('SpecVersion')]
     private string $specVersion = '1.52';
 
-    /**
-     * @SerializedName("CustomerId")
-     */
+    #[SerializedName('CustomerId')]
     private string $customerId;
 
-    /**
-     * @SerializedName("RequestId")
-     */
+    #[SerializedName('RequestId')]
     private ?string $requestId;
 
-    /**
-     * @SerializedName("RetryIndicator")
-     */
+    #[SerializedName('RetryIndicator')]
     private int $retryIndicator;
 
-    /**
-     * @SerializedName("ClientInfo")
-     */
+    #[SerializedName('ClientInfo')]
     private ?ClientInfo $clientInfo = null;
 
     public function __construct(
         string $customerId,
         ?string $requestId = null,
-        int $retryIndicator = RequestConfig::MIN_RETRY_INDICATOR
+        int $retryIndicator = RequestConfig::MIN_RETRY_INDICATOR,
     ) {
         $this->customerId = $customerId;
         $this->requestId = $requestId;

--- a/lib/SaferpayJson/Request/Container/ReturnUrl.php
+++ b/lib/SaferpayJson/Request/Container/ReturnUrl.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class ReturnUrl
 {
-    /**
-     * @SerializedName("Url")
-     */
+    #[SerializedName('Url')]
     private string $url;
 
     public function __construct(string $url)

--- a/lib/SaferpayJson/Request/Container/RiskFactors.php
+++ b/lib/SaferpayJson/Request/Container/RiskFactors.php
@@ -14,24 +14,16 @@ final class RiskFactors
     public const DELIVERY_TYPE_PICKUP = 'PICKUP';
     public const DELIVERY_TYPE_HQ = 'HQ';
 
-    /**
-     * @SerializedName("DeliveryType")
-     */
+    #[SerializedName('DeliveryType')]
     private ?string $deliveryType = null;
 
-    /**
-     * @SerializedName("PayerProfile")
-     */
+    #[SerializedName('PayerProfile')]
     private ?PayerProfile $payerProfile = null;
 
-    /**
-     * @SerializedName("IsB2B")
-     */
+    #[SerializedName('IsB2B')]
     private ?bool $isB2B = null;
 
-    /**
-     * @SerializedName("DeviceFingerprintTransactionId")
-     */
+    #[SerializedName('DeviceFingerprintTransactionId')]
     private ?string $deviceFingerprintTransactionId = null;
 
     public function getDeliveryType(): ?string

--- a/lib/SaferpayJson/Request/Container/SaferpayFields.php
+++ b/lib/SaferpayJson/Request/Container/SaferpayFields.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class SaferpayFields
 {
-    /**
-     * @SerializedName("Token")
-     */
+    #[SerializedName('Token')]
     private string $token;
 
     public function __construct(string $token)

--- a/lib/SaferpayJson/Request/Container/SchemeToken.php
+++ b/lib/SaferpayJson/Request/Container/SchemeToken.php
@@ -16,34 +16,22 @@ final class SchemeToken
     public const TOKEN_TYPE_MDES = 'MDES';
     public const TOKEN_TYPE_VTS = 'VTS';
 
-    /**
-     * @SerializedName("Number")
-     */
+    #[SerializedName('Number')]
     private string $number;
 
-    /**
-     * @SerializedName("ExpMonth")
-     */
+    #[SerializedName('ExpMonth')]
     private int $expMonth;
 
-    /**
-     * @SerializedName("ExpYear")
-     */
+    #[SerializedName('ExpYear')]
     private int $expYear;
 
-    /**
-     * @SerializedName("AuthValue")
-     */
+    #[SerializedName('AuthValue')]
     private string $authValue;
 
-    /**
-     * @SerializedName("Eci")
-     */
+    #[SerializedName('Eci')]
     private ?string $eci = null;
 
-    /**
-     * @SerializedName("TokenType")
-     */
+    #[SerializedName('TokenType')]
     private string $tokenType;
 
     public function __construct(string $number, int $expMonth, int $expYear, string $authValue, string $tokenType)

--- a/lib/SaferpayJson/Request/Container/SecureCardData/Notification.php
+++ b/lib/SaferpayJson/Request/Container/SecureCardData/Notification.php
@@ -8,12 +8,8 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Notification
 {
-    /**
-     * @var string|null
-     *
-     * @SerializedName("NotifyUrl")
-     */
-    private $notifyUrl;
+    #[SerializedName('NotifyUrl')]
+    private ?string $notifyUrl = null;
 
     public function getNotifyUrl(): ?string
     {

--- a/lib/SaferpayJson/Request/Container/Styling.php
+++ b/lib/SaferpayJson/Request/Container/Styling.php
@@ -12,19 +12,13 @@ final class Styling
     public const THEME_SIX = 'SIX';
     public const THEME_NONE = 'NONE';
 
-    /**
-     * @SerializedName("CssUrl")
-     */
+    #[SerializedName('CssUrl')]
     private ?string $cssUrl = null;
 
-    /**
-     * @SerializedName("ContentSecurityEnabled")
-     */
+    #[SerializedName('ContentSecurityEnabled')]
     private ?bool $contentSecurityEnabled = null;
 
-    /**
-     * @SerializedName("Theme")
-     */
+    #[SerializedName('Theme')]
     private ?string $theme = null;
 
     public function getCssUrl(): ?string

--- a/lib/SaferpayJson/Request/Container/Transaction/Ideal.php
+++ b/lib/SaferpayJson/Request/Container/Transaction/Ideal.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Ideal
 {
-    /**
-     * @SerializedName("AccountHolderName")
-     */
+    #[SerializedName('AccountHolderName')]
     private string $accountHolderName;
 
     public function __construct(string $accountHolderName)

--- a/lib/SaferpayJson/Request/Container/Transaction/Notification.php
+++ b/lib/SaferpayJson/Request/Container/Transaction/Notification.php
@@ -8,12 +8,8 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Notification
 {
-    /**
-     * @var string|null
-     *
-     * @SerializedName("PayerDccReceiptEmail")
-     */
-    private $payerDccReceiptEmail;
+    #[SerializedName('PayerDccReceiptEmail')]
+    private ?string $payerDccReceiptEmail = null;
 
     public function getPayerDccReceiptEmail(): ?string
     {

--- a/lib/SaferpayJson/Request/Container/Transaction/PaymentMethodsOptions.php
+++ b/lib/SaferpayJson/Request/Container/Transaction/PaymentMethodsOptions.php
@@ -9,14 +9,9 @@ use JMS\Serializer\Annotation\Type;
 
 final class PaymentMethodsOptions
 {
-    /**
-     * @var Ideal|null
-     *
-     * @SerializedName("Ideal")
-     *
-     * @Type("Ticketpark\SaferpayJson\Request\Container\Transaction\Ideal")
-     */
-    private $ideal;
+    #[SerializedName('Ideal')]
+    #[Type("Ticketpark\SaferpayJson\Request\Container\Transaction\Ideal")]
+    private ?Ideal $ideal = null;
 
     public function getIdeal(): ?Ideal
     {

--- a/lib/SaferpayJson/Request/Container/TransactionReference.php
+++ b/lib/SaferpayJson/Request/Container/TransactionReference.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class TransactionReference
 {
-    /**
-     * @SerializedName("TransactionId")
-     */
+    #[SerializedName('TransactionId')]
     private ?string $transactionId = null;
 
-    /**
-     * @SerializedName("OrderId")
-     */
+    #[SerializedName('OrderId')]
     private ?string $orderId = null;
 
     public function getTransactionId(): ?string

--- a/lib/SaferpayJson/Request/Container/Twint.php
+++ b/lib/SaferpayJson/Request/Container/Twint.php
@@ -9,11 +9,8 @@ use JMS\Serializer\Annotation\Type;
 
 final class Twint
 {
-    /**
-     * @SerializedName("CertificateExpirationDate")
-     *
-     * @Type("DateTime<'Y-m-d\TH:i:s.uT'>")
-     */
+    #[SerializedName('CertificateExpirationDate')]
+    #[Type("DateTime<'Y-m-d\TH:i:s.uT'>")]
     private ?\DateTime $certificateExpirationDate = null;
 
     public function getCertificateExpirationDate(): ?\DateTime

--- a/lib/SaferpayJson/Request/Container/UpdateAlias.php
+++ b/lib/SaferpayJson/Request/Container/UpdateAlias.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class UpdateAlias
 {
-    /**
-     * @SerializedName("Id")
-     */
+    #[SerializedName('Id')]
     private string $id;
 
-    /**
-     * @SerializedName("Lifetime")
-     */
+    #[SerializedName('Lifetime')]
     private ?int $lifetime = null;
 
     public function __construct(string $id)

--- a/lib/SaferpayJson/Request/Container/UpdatePaymentMeans.php
+++ b/lib/SaferpayJson/Request/Container/UpdatePaymentMeans.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class UpdatePaymentMeans
 {
-    /**
-     * @SerializedName("Card")
-     */
+    #[SerializedName('Card')]
     private Card $card;
 
     public function __construct(Card $card)

--- a/lib/SaferpayJson/Request/PaymentPage/AssertRequest.php
+++ b/lib/SaferpayJson/Request/PaymentPage/AssertRequest.php
@@ -16,14 +16,12 @@ final class AssertRequest extends Request
     public const API_PATH = '/Payment/v1/PaymentPage/Assert';
     public const RESPONSE_CLASS = AssertResponse::class;
 
-    /**
-     * @SerializedName("Token")
-     */
+    #[SerializedName('Token')]
     private string $token;
 
     public function __construct(
         RequestConfig $requestConfig,
-        string $token
+        string $token,
     ) {
         $this->token = $token;
 

--- a/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
@@ -61,100 +61,62 @@ final class InitializeRequest extends Request
     public const CONDITION_WITH_SUCCESSFUL_THREE_DS_CHALLENGE = 'WITH_SUCCESSFUL_THREE_DS_CHALLENGE';
     public const CONDITION_NONE = 'NONE';
 
-    /**
-     * @SerializedName("TerminalId")
-     */
+    #[SerializedName('TerminalId')]
     private string $terminalId;
 
-    /**
-     * @SerializedName("Payment")
-     */
+    #[SerializedName('Payment')]
     private Payment $payment;
 
-    /**
-     * @SerializedName("ReturnUrl")
-     */
+    #[SerializedName('ReturnUrl')]
     private ReturnUrl $returnUrl;
 
-    /**
-     * @SerializedName("ConfigSet")
-     */
+    #[SerializedName('ConfigSet')]
     private ?string $configSet = null;
 
-    /**
-     * @var array<string>|null
-     *
-     * @SerializedName("PaymentMethods")
-     */
+    #[SerializedName('PaymentMethods')]
     private ?array $paymentMethods = null;
 
-    /**
-     * @SerializedName("PaymentMethodsOptions")
-     */
+    #[SerializedName('PaymentMethodsOptions')]
     private ?PaymentMethodsOptions $paymentMethodsOptions = null;
 
-    /**
-     * @SerializedName("Authentication")
-     */
+    #[SerializedName('Authentication')]
     private ?Authentication $authentication = null;
 
-    /**
-     * @var array<string>|null
-     *
-     * @SerializedName("Wallets")
-     */
+    #[SerializedName('Wallets')]
     private ?array $wallets = null;
 
-    /**
-     * @SerializedName("Payer")
-     */
+    #[SerializedName('Payer')]
     private ?Payer $payer = null;
 
-    /**
-     * @SerializedName("RegisterAlias")
-     */
+    #[SerializedName('RegisterAlias')]
     private ?RegisterAlias $registerAlias = null;
 
-    /**
-     * @SerializedName("Notification")
-     */
+    #[SerializedName('Notification')]
     private ?Notification $notification = null;
 
-    /**
-     * @SerializedName("BillingAddressForm")
-     */
+    #[SerializedName('BillingAddressForm')]
     private ?AddressForm $billingAddressForm = null;
 
-    /**
-     * @SerializedName("DeliveryAddressForm")
-     */
+    #[SerializedName('DeliveryAddressForm')]
     private ?AddressForm $deliveryAddressForm = null;
 
-    /**
-     * @SerializedName("CardForm")
-     */
+    #[SerializedName('CardForm')]
     private ?CardForm $cardForm = null;
 
-    /**
-     * @SerializedName("Condition")
-     */
+    #[SerializedName('Condition')]
     private ?string $condition = null;
 
-    /**
-     * @SerializedName("Order")
-     */
+    #[SerializedName('Order')]
     private ?Order $order = null;
 
-    /**
-     * @SerializedName("RiskFactors")
-     */
+    #[SerializedName('RiskFactors')]
     private ?RiskFactors $riskFactors = null;
 
     public function __construct(
         RequestConfig $requestConfig,
         string $terminalId,
         Payment $payment,
-        ReturnUrl $returnUrl
+        ReturnUrl $returnUrl,
     ) {
         $this->terminalId = $terminalId;
         $this->payment = $payment;

--- a/lib/SaferpayJson/Request/Request.php
+++ b/lib/SaferpayJson/Request/Request.php
@@ -20,9 +20,7 @@ abstract class Request
 {
     private const ERROR_RESPONSE_CLASS = ErrorResponse::class;
 
-    /**
-     * @Exclude
-     */
+    #[Exclude]
     private RequestConfig $requestConfig;
 
     abstract public function execute(): Response;
@@ -39,11 +37,8 @@ abstract class Request
         $this->requestConfig = $requestConfig;
     }
 
-    /**
-     * @SerializedName("RequestHeader")
-     *
-     * @VirtualProperty
-     */
+    #[SerializedName('RequestHeader')]
+    #[VirtualProperty]
     public function getRequestHeader(): RequestHeader
     {
         return new RequestHeader(

--- a/lib/SaferpayJson/Request/RequestConfig.php
+++ b/lib/SaferpayJson/Request/RequestConfig.php
@@ -32,7 +32,7 @@ final class RequestConfig
         string $apiSecret,
         string $customerId,
         bool $test = false,
-        ?string $rootUrl = null
+        ?string $rootUrl = null,
     ) {
         $this->apiKey = $apiKey;
         $this->apiSecret = $apiSecret;

--- a/lib/SaferpayJson/Request/SecureCardData/AliasAssertInsertRequest.php
+++ b/lib/SaferpayJson/Request/SecureCardData/AliasAssertInsertRequest.php
@@ -16,9 +16,7 @@ final class AliasAssertInsertRequest extends Request
     public const API_PATH = '/Payment/v1/Alias/AssertInsert';
     public const RESPONSE_CLASS = AliasAssertInsertResponse::class;
 
-    /**
-     * @SerializedName("Token")
-     */
+    #[SerializedName('Token')]
     private string $token;
 
     public function __construct(RequestConfig $requestConfig, string $token)

--- a/lib/SaferpayJson/Request/SecureCardData/AliasDeleteRequest.php
+++ b/lib/SaferpayJson/Request/SecureCardData/AliasDeleteRequest.php
@@ -16,9 +16,7 @@ final class AliasDeleteRequest extends Request
     public const API_PATH = '/Payment/v1/Alias/Delete';
     public const RESPONSE_CLASS = AliasDeleteResponse::class;
 
-    /**
-     * @SerializedName("AliasId")
-     */
+    #[SerializedName('AliasId')]
     private string $aliasId;
 
     public function __construct(RequestConfig $requestConfig, string $aliasId)

--- a/lib/SaferpayJson/Request/SecureCardData/AliasInsertDirectRequest.php
+++ b/lib/SaferpayJson/Request/SecureCardData/AliasInsertDirectRequest.php
@@ -21,29 +21,19 @@ final class AliasInsertDirectRequest extends Request
     public const API_PATH = '/Payment/v1/Alias/InsertDirect';
     public const RESPONSE_CLASS = AliasInsertDirectResponse::class;
 
-    /**
-     * @SerializedName("RegisterAlias")
-     */
+    #[SerializedName('RegisterAlias')]
     private RegisterAlias $registerAlias;
 
-    /**
-     * @SerializedName("PaymentMeans")
-     */
+    #[SerializedName('PaymentMeans')]
     private PaymentMeans $paymentMeans;
 
-    /**
-     * @SerializedName("Check")
-     */
+    #[SerializedName('Check')]
     private ?Check $check = null;
 
-    /**
-     * @SerializedName("ExternalThreeDS")
-     */
+    #[SerializedName('ExternalThreeDS')]
     private ?ExternalThreeDS $externalThreeDS = null;
 
-    /**
-     * @SerializedName("IssuerReference")
-     */
+    #[SerializedName('IssuerReference')]
     private ?IssuerReference $issuerReference = null;
 
     public function __construct(RequestConfig $requestConfig, RegisterAlias $registerAlias, PaymentMeans $paymentMeans)

--- a/lib/SaferpayJson/Request/SecureCardData/AliasInsertRequest.php
+++ b/lib/SaferpayJson/Request/SecureCardData/AliasInsertRequest.php
@@ -40,63 +40,41 @@ final class AliasInsertRequest extends Request
     public const TYPE_POSTFINANCE = 'POSTFINANCE';
     public const TYPE_TWINT = 'TWINT';
 
-    /**
-     * @SerializedName("RegisterAlias")
-     */
+    #[SerializedName('RegisterAlias')]
     private RegisterAlias $registerAlias;
 
-    /**
-     * @SerializedName("Type")
-     */
+    #[SerializedName('Type')]
     private string $type;
 
-    /**
-     * @SerializedName("ReturnUrl")
-     */
+    #[SerializedName('ReturnUrl')]
     private ReturnUrl $returnUrl;
 
-    /**
-     * @SerializedName("Styling")
-     */
+    #[SerializedName('Styling')]
     private ?Styling $styling = null;
 
-    /**
-     * @SerializedName("LanguageCode")
-     */
+    #[SerializedName('LanguageCode')]
     private ?string $languageCode = null;
 
-    /**
-     * @SerializedName("Check")
-     */
+    #[SerializedName('Check')]
     private ?Check $check = null;
 
-    /**
-     * @var array<string>|null
-     *
-     * @SerializedName("PaymentMethods")
-     */
+    #[SerializedName('PaymentMethods')]
     private ?array $paymentMethods = null;
 
-    /**
-     * @SerializedName("CardForm")
-     */
+    #[SerializedName('CardForm')]
     private ?CardForm $cardForm = null;
 
-    /**
-     * @SerializedName("PaymentMeans")
-     */
+    #[SerializedName('PaymentMeans')]
     private ?PaymentMeans $paymentMeans = null;
 
-    /**
-     * @SerializedName("Notification")
-     */
+    #[SerializedName('Notification')]
     private ?Notification $notification = null;
 
     public function __construct(
         RequestConfig $requestConfig,
         RegisterAlias $registerAlias,
         string $type,
-        ReturnUrl $returnUrl
+        ReturnUrl $returnUrl,
     ) {
         $this->registerAlias = $registerAlias;
         $this->type = $type;

--- a/lib/SaferpayJson/Request/SecureCardData/AliasUpdateRequest.php
+++ b/lib/SaferpayJson/Request/SecureCardData/AliasUpdateRequest.php
@@ -18,20 +18,16 @@ final class AliasUpdateRequest extends Request
     public const API_PATH = '/Payment/v1/Alias/Update';
     public const RESPONSE_CLASS = AliasUpdateResponse::class;
 
-    /**
-     * @SerializedName("UpdateAlias")
-     */
+    #[SerializedName('UpdateAlias')]
     private UpdateAlias $updateAlias;
 
-    /**
-     * @SerializedName("UpdatePaymentMeans")
-     */
+    #[SerializedName('UpdatePaymentMeans')]
     private UpdatePaymentMeans $updatePaymentMeans;
 
     public function __construct(
         RequestConfig $requestConfig,
         UpdateAlias $updateAlias,
-        UpdatePaymentMeans $updatePaymentMeans
+        UpdatePaymentMeans $updatePaymentMeans,
     ) {
         $this->updateAlias = $updateAlias;
         $this->updatePaymentMeans = $updatePaymentMeans;

--- a/lib/SaferpayJson/Request/Transaction/AuthorizeDirectRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/AuthorizeDirectRequest.php
@@ -27,61 +27,41 @@ final class AuthorizeDirectRequest extends Request
     public const INITIATOR_MERCHANT = 'MERCHANT';
     public const INITIATOR_PAYER = 'PAYER';
 
-    /**
-     * @SerializedName("TerminalId")
-     */
+    #[SerializedName('TerminalId')]
     private string $terminalId;
 
-    /**
-     * @SerializedName("Payment")
-     */
+    #[SerializedName('Payment')]
     private Payment $payment;
 
-    /**
-     * @SerializedName("PaymentMeans")
-     */
+    #[SerializedName('PaymentMeans')]
     private PaymentMeans $paymentMeans;
 
-    /**
-     * @SerializedName("Authentication")
-     */
+    #[SerializedName('Authentication')]
     private ?Authentication $authentication = null;
 
-    /**
-     * @SerializedName("Dcc")
-     */
+    #[SerializedName('Dcc')]
     private ?DccReference $dcc = null;
 
-    /**
-     * @SerializedName("RegisterAlias")
-     */
+    #[SerializedName('RegisterAlias')]
     private ?RegisterAlias $registerAlias = null;
 
-    /**
-     * @SerializedName("Payer")
-     */
+    #[SerializedName('Payer')]
     private ?Payer $payer = null;
 
-    /**
-     * @SerializedName("Order")
-     */
+    #[SerializedName('Order')]
     private ?Order $order = null;
 
-    /**
-     * @SerializedName("RiskFactors")
-     */
+    #[SerializedName('RiskFactors')]
     private ?RiskFactors $riskFactors = null;
 
-    /**
-     * @SerializedName("Initiator")
-     */
+    #[SerializedName('Initiator')]
     private ?string $initiator = null;
 
     public function __construct(
         RequestConfig $requestConfig,
         string $terminalId,
         Payment $payment,
-        PaymentMeans $paymentMeans
+        PaymentMeans $paymentMeans,
     ) {
         $this->terminalId = $terminalId;
         $this->payment = $payment;

--- a/lib/SaferpayJson/Request/Transaction/AuthorizeReferencedRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/AuthorizeReferencedRequest.php
@@ -20,41 +20,29 @@ final class AuthorizeReferencedRequest extends Request
     public const API_PATH = '/Payment/v1/Transaction/AuthorizeReferenced';
     public const RESPONSE_CLASS = AuthorizeReferencedResponse::class;
 
-    /**
-     * @SerializedName("TerminalId")
-     */
+    #[SerializedName('TerminalId')]
     private string $terminalId;
 
-    /**
-     * @SerializedName("Payment")
-     */
+    #[SerializedName('Payment')]
     private Payment $payment;
 
-    /**
-     * @SerializedName("TransactionReference")
-     */
+    #[SerializedName('TransactionReference')]
     private TransactionReference $transactionReference;
 
-    /**
-     * @SerializedName("Authentication")
-     */
+    #[SerializedName('Authentication')]
     private ?Authentication $authentication = null;
 
-    /**
-     * @SerializedName("SuppressDcc")
-     */
+    #[SerializedName('SuppressDcc')]
     private ?bool $suppressDcc = null;
 
-    /**
-     * @SerializedName("Notification")
-     */
+    #[SerializedName('Notification')]
     private ?Notification $notification = null;
 
     public function __construct(
         RequestConfig $requestConfig,
         string $terminalId,
         Payment $payment,
-        TransactionReference $transactionReference
+        TransactionReference $transactionReference,
     ) {
         $this->terminalId = $terminalId;
         $this->payment = $payment;

--- a/lib/SaferpayJson/Request/Transaction/AuthorizeRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/AuthorizeRequest.php
@@ -21,29 +21,21 @@ final class AuthorizeRequest extends Request
     public const CONDITION_WITH_SUCCESSFUL_THREE_DS_CHALLENGE = 'WITH_SUCCESSFUL_THREE_DS_CHALLENGE';
     public const CONDITION_NONE = 'NONE';
 
-    /**
-     * @SerializedName("Token")
-     */
+    #[SerializedName('Token')]
     private string $token;
 
-    /**
-     * @SerializedName("Condition")
-     */
+    #[SerializedName('Condition')]
     private ?string $condition = null;
 
-    /**
-     * @SerializedName("VerificationCode")
-     */
+    #[SerializedName('VerificationCode')]
     private ?string $verificationCode = null;
 
-    /**
-     * @SerializedName("RegisterAlias")
-     */
+    #[SerializedName('RegisterAlias')]
     private ?RegisterAlias $registerAlias = null;
 
     public function __construct(
         RequestConfig $requestConfig,
-        string $token
+        string $token,
     ) {
         $this->token = $token;
 

--- a/lib/SaferpayJson/Request/Transaction/CancelRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/CancelRequest.php
@@ -17,14 +17,12 @@ final class CancelRequest extends Request
     public const API_PATH = '/Payment/v1/Transaction/Cancel';
     public const RESPONSE_CLASS = CancelResponse::class;
 
-    /**
-     * @SerializedName("TransactionReference")
-     */
+    #[SerializedName('TransactionReference')]
     private TransactionReference $transactionReference;
 
     public function __construct(
         RequestConfig $requestConfig,
-        TransactionReference $transactionReference
+        TransactionReference $transactionReference,
     ) {
         $this->transactionReference = $transactionReference;
 

--- a/lib/SaferpayJson/Request/Transaction/CaptureRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/CaptureRequest.php
@@ -22,39 +22,27 @@ final class CaptureRequest extends Request
     public const API_PATH = '/Payment/v1/Transaction/Capture';
     public const RESPONSE_CLASS = CaptureResponse::class;
 
-    /**
-     * @SerializedName("TransactionReference")
-     */
+    #[SerializedName('TransactionReference')]
     private TransactionReference $transactionReference;
 
-    /**
-     * @SerializedName("Amount")
-     */
+    #[SerializedName('Amount')]
     private ?Amount $amount = null;
 
-    /**
-     * @SerializedName("PendingNotification")
-     */
+    #[SerializedName('PendingNotification')]
     private ?PendingNotification $pendingNotification = null;
 
-    /**
-     * @SerializedName("Marketplace")
-     */
+    #[SerializedName('Marketplace')]
     private ?Marketplace $marketplace = null;
 
-    /**
-     * @SerializedName("MastercardIssuerInstallments")
-     */
+    #[SerializedName('MastercardIssuerInstallments')]
     private ?MastercardIssuerInstallments $mastercardIssuerInstallments = null;
 
-    /**
-     * @SerializedName("MerchantFundDistributor")
-     */
+    #[SerializedName('MerchantFundDistributor')]
     private ?MerchantFundDistributor $merchantFundDistributor = null;
 
     public function __construct(
         RequestConfig $requestConfig,
-        TransactionReference $transactionReference
+        TransactionReference $transactionReference,
     ) {
         $this->transactionReference = $transactionReference;
 

--- a/lib/SaferpayJson/Request/Transaction/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/InitializeRequest.php
@@ -41,83 +41,53 @@ final class InitializeRequest extends Request
 
     public const WALLET_MASTERPASS = 'MASTERPASS';
 
-    /**
-     * @SerializedName("ConfigSet")
-     */
+    #[SerializedName('ConfigSet')]
     private ?string $configSet = null;
 
-    /**
-     * @SerializedName("TerminalId")
-     */
+    #[SerializedName('TerminalId')]
     private string $terminalId;
 
-    /**
-     * @SerializedName("Payment")
-     */
+    #[SerializedName('Payment')]
     private Payment $payment;
 
-    /**
-     * @SerializedName("PaymentMeans")
-     */
+    #[SerializedName('PaymentMeans')]
     private ?PaymentMeans $paymentMeans = null;
 
-    /**
-     * @SerializedName("Authentication")
-     */
+    #[SerializedName('Authentication')]
     private ?Authentication $authentication = null;
 
-    /**
-     * @SerializedName("Payer")
-     */
+    #[SerializedName('Payer')]
     private ?Payer $payer = null;
 
-    /**
-     * @SerializedName("ReturnUrl")
-     */
-    private ?ReturnUrl $returnUrl;
+    #[SerializedName('ReturnUrl')]
+    private ReturnUrl $returnUrl;
 
-    /**
-     * @SerializedName("Styling")
-     */
+    #[SerializedName('Styling')]
     private ?Styling $styling = null;
 
-    /**
-     * @var array<string>|null
-     *
-     * @SerializedName("PaymentMethods")
-     */
+    #[SerializedName('PaymentMethods')]
     private ?array $paymentMethods = null;
 
-    /**
-     * @SerializedName("Order")
-     */
+    #[SerializedName('Order')]
     private ?Order $order = null;
 
-    /**
-     * @SerializedName("RiskFactors")
-     */
+    #[SerializedName('RiskFactors')]
     private ?RiskFactors $riskFactors = null;
 
-    /**
-     * @SerializedName("CardForm")
-     */
+    #[SerializedName('CardForm')]
     private ?CardForm $cardForm = null;
 
-    /**
-     * @SerializedName("RedirectNotifyUrls")
-     */
+    #[SerializedName('RedirectNotifyUrls')]
     private ?RedirectNotifyUrls $redirectNotifyUrls = null;
 
-    /**
-     * @SerializedName("Notification")
-     */
+    #[SerializedName('Notification')]
     private ?Notification $notification = null;
 
     public function __construct(
         RequestConfig $requestConfig,
         string $terminalId,
         Payment $payment,
-        ReturnUrl $returnUrl
+        ReturnUrl $returnUrl,
     ) {
         $this->terminalId = $terminalId;
         $this->payment = $payment;
@@ -234,7 +204,7 @@ final class InitializeRequest extends Request
         return $this->payer;
     }
 
-    public function getReturnUrl(): ?ReturnUrl
+    public function getReturnUrl(): ReturnUrl
     {
         return $this->returnUrl;
     }

--- a/lib/SaferpayJson/Request/Transaction/InquireRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/InquireRequest.php
@@ -17,14 +17,12 @@ final class InquireRequest extends Request
     public const API_PATH = '/Payment/v1/Transaction/Inquire';
     public const RESPONSE_CLASS = InquireResponse::class;
 
-    /**
-     * @SerializedName("TransactionReference")
-     */
+    #[SerializedName('TransactionReference')]
     private TransactionReference $transactionReference;
 
     public function __construct(
         RequestConfig $requestConfig,
-        TransactionReference $transactionReference
+        TransactionReference $transactionReference,
     ) {
         $this->transactionReference = $transactionReference;
 

--- a/lib/SaferpayJson/Request/Transaction/RefundRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/RefundRequest.php
@@ -20,30 +20,22 @@ final class RefundRequest extends Request
     public const API_PATH = '/Payment/v1/Transaction/Refund';
     public const RESPONSE_CLASS = RefundResponse::class;
 
-    /**
-     * @SerializedName("Refund")
-     */
+    #[SerializedName('Refund')]
     private Refund $refund;
 
-    /**
-     * @SerializedName("CaptureReference")
-     */
+    #[SerializedName('CaptureReference')]
     private CaptureReference $captureReference;
 
-    /**
-     * @SerializedName("PendingNotification")
-     */
+    #[SerializedName('PendingNotification')]
     private ?PendingNotification $pendingNotification = null;
 
-    /**
-     * @SerializedName("PaymentMethodsOptions")
-     */
+    #[SerializedName('PaymentMethodsOptions')]
     private ?PaymentMethodsOptions $paymentMethodsOptions = null;
 
     public function __construct(
         RequestConfig $requestConfig,
         Refund $refund,
-        CaptureReference $captureReference
+        CaptureReference $captureReference,
     ) {
         $this->refund = $refund;
         $this->captureReference = $captureReference;

--- a/lib/SaferpayJson/Response/Container/Address.php
+++ b/lib/SaferpayJson/Response/Container/Address.php
@@ -14,76 +14,47 @@ final class Address
     public const GENDER_DIVERSE = 'DIVERSE';
     public const GENDER_COMPANY = 'COMPANY';
 
-    /**
-     * @SerializedName("FirstName")
-     */
+    #[SerializedName('FirstName')]
     private ?string $firstName = null;
 
-    /**
-     * @SerializedName("LastName")
-     */
+    #[SerializedName('LastName')]
     private ?string $lastName = null;
 
-    /**
-     * @SerializedName("Company")
-     */
+    #[SerializedName('Company')]
     private ?string $company = null;
 
-    /**
-     * @SerializedName("Gender")
-     */
+    #[SerializedName('Gender')]
     private ?string $gender = null;
 
-    /**
-     * @SerializedName("Street")
-     */
+    #[SerializedName('Street')]
     private ?string $street = null;
 
-    /**
-     * @SerializedName("Zip")
-     */
+    #[SerializedName('Zip')]
     private ?string $zip = null;
 
-    /**
-     * @SerializedName("City")
-     */
+    #[SerializedName('City')]
     private ?string $city = null;
 
-    /**
-     * @SerializedName("CountryCode")
-     */
+    #[SerializedName('CountryCode')]
     private ?string $countryCode = null;
 
-    /**
-     * @SerializedName("Email")
-     */
+    #[SerializedName('Email')]
     private ?string $email = null;
 
-    /**
-     * @SerializedName("DateOfBirth")
-     *
-     * @Type("DateTime<'Y-m-d'>")
-     */
+    #[SerializedName('DateOfBirth')]
+    #[Type("DateTime<'Y-m-d'>")]
     private ?\DateTime $dateOfBirth = null;
 
-    /**
-     * @SerializedName("Street2")
-     */
+    #[SerializedName('Street2')]
     private ?string $street2 = null;
 
-    /**
-     * @SerializedName("CountrySubdivisionCode")
-     */
+    #[SerializedName('CountrySubdivisionCode')]
     private ?string $countrySubdivisionCode = null;
 
-    /**
-     * @SerializedName("Phone")
-     */
+    #[SerializedName('Phone')]
     private ?string $phone = null;
 
-    /**
-     * @SerializedName("VatNumber")
-     */
+    #[SerializedName('VatNumber')]
     private ?string $vatNumber = null;
 
     public function getFirstName(): ?string

--- a/lib/SaferpayJson/Response/Container/Alias.php
+++ b/lib/SaferpayJson/Response/Container/Alias.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Alias
 {
-    /**
-     * @SerializedName("Id")
-     */
+    #[SerializedName('Id')]
     private ?string $id = null;
 
-    /**
-     * @SerializedName("Lifetime")
-     */
+    #[SerializedName('Lifetime')]
     private ?int $lifetime = null;
 
     public function getId(): ?string

--- a/lib/SaferpayJson/Response/Container/Amount.php
+++ b/lib/SaferpayJson/Response/Container/Amount.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Amount
 {
-    /**
-     * @SerializedName("Value")
-     */
+    #[SerializedName('Value')]
     private ?int $value = null;
 
-    /**
-     * @SerializedName("CurrencyCode")
-     */
+    #[SerializedName('CurrencyCode')]
     private ?string $currencyCode = null;
 
     public function getValue(): ?int

--- a/lib/SaferpayJson/Response/Container/AuthenticationResult.php
+++ b/lib/SaferpayJson/Response/Container/AuthenticationResult.php
@@ -14,19 +14,13 @@ final class AuthenticationResult
     public const AUTHENTICATION_TYPE_UNSPECIFIED = 'UNSPECIFIED';
     public const AUTHENTICATION_TYPE_NONE = 'NONE';
 
-    /**
-     * @SerializedName("Authenticated")
-     */
+    #[SerializedName('Authenticated')]
     private ?bool $authenticated = null;
 
-    /**
-     * @SerializedName("AuthenticationType")
-     */
+    #[SerializedName('AuthenticationType')]
     private ?string $authenticationType = null;
 
-    /**
-     * @SerializedName("Message")
-     */
+    #[SerializedName('Message')]
     private ?string $message = null;
 
     public function isAuthenticated(): ?bool

--- a/lib/SaferpayJson/Response/Container/BankAccount.php
+++ b/lib/SaferpayJson/Response/Container/BankAccount.php
@@ -8,29 +8,19 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class BankAccount
 {
-    /**
-     * @SerializedName("Iban")
-     */
+    #[SerializedName('Iban')]
     private ?string $iban = null;
 
-    /**
-     * @SerializedName("HolderName")
-     */
+    #[SerializedName('HolderName')]
     private ?string $holderName = null;
 
-    /**
-     * @SerializedName("BIC")
-     */
+    #[SerializedName('BIC')]
     private ?string $bic = null;
 
-    /**
-     * @SerializedName("BankName")
-     */
+    #[SerializedName('BankName')]
     private ?string $bankName = null;
 
-    /**
-     * @SerializedName("CountryCode")
-     */
+    #[SerializedName('CountryCode')]
     private ?string $countryCode = null;
 
     public function getIban(): ?string

--- a/lib/SaferpayJson/Response/Container/Brand.php
+++ b/lib/SaferpayJson/Response/Container/Brand.php
@@ -32,14 +32,10 @@ final class Brand
     public const PAYMENT_METHOD_WERO = 'WERO';
     public const PAYMENT_METHOD_WECHATPAY = 'WECHATPAY';
 
-    /**
-     * @SerializedName("PaymentMethod")
-     */
+    #[SerializedName('PaymentMethod')]
     private ?string $paymentMethod = null;
 
-    /**
-     * @SerializedName("Name")
-     */
+    #[SerializedName('Name')]
     private ?string $name = null;
 
     public function getPaymentMethod(): ?string

--- a/lib/SaferpayJson/Response/Container/Card.php
+++ b/lib/SaferpayJson/Response/Container/Card.php
@@ -18,49 +18,31 @@ final class Card
     public const FUNDING_SOURCE_DEBIT = 'DEBIT';
     public const FUNDING_SOURCE_PREPAID = 'PREPAID';
 
-    /**
-     * @SerializedName("MaskedNumber")
-     */
+    #[SerializedName('MaskedNumber')]
     private ?string $maskedNumber = null;
 
-    /**
-     * @SerializedName("ExpYear")
-     */
+    #[SerializedName('ExpYear')]
     private ?int $expYear = null;
 
-    /**
-     * @SerializedName("ExpMonth")
-     */
+    #[SerializedName('ExpMonth')]
     private ?int $expMonth = null;
 
-    /**
-     * @SerializedName("HolderName")
-     */
+    #[SerializedName('HolderName')]
     private ?string $holderName = null;
 
-    /**
-     * @SerializedName("HolderSegment")
-     */
+    #[SerializedName('HolderSegment')]
     private ?string $holderSegment = null;
 
-    /**
-     * @SerializedName("FundingSource")
-     */
+    #[SerializedName('FundingSource')]
     private ?string $fundingSource = null;
 
-    /**
-     * @SerializedName("CountryCode")
-     */
+    #[SerializedName('CountryCode')]
     private ?string $countryCode = null;
 
-    /**
-     * @SerializedName("HashValue")
-     */
+    #[SerializedName('HashValue')]
     private ?string $hashValue = null;
 
-    /**
-     * @SerializedName("TokenPan")
-     */
+    #[SerializedName('TokenPan')]
     private ?TokenPan $tokenPan = null;
 
     public function getMaskedNumber(): ?string

--- a/lib/SaferpayJson/Response/Container/CheckResult.php
+++ b/lib/SaferpayJson/Response/Container/CheckResult.php
@@ -8,19 +8,13 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class CheckResult
 {
-    /**
-     * @SerializedName("Result")
-     */
+    #[SerializedName('Result')]
     private ?string $result = null;
 
-    /**
-     * @SerializedName("Message")
-     */
+    #[SerializedName('Message')]
     private ?string $message = null;
 
-    /**
-     * @SerializedName("Authentication")
-     */
+    #[SerializedName('Authentication')]
     private ?HolderAuthentication $authentication = null;
 
     public function getResult(): ?string

--- a/lib/SaferpayJson/Response/Container/ChosenPlan.php
+++ b/lib/SaferpayJson/Response/Container/ChosenPlan.php
@@ -8,39 +8,25 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class ChosenPlan
 {
-    /**
-     * @SerializedName("NumberOfInstallments")
-     */
+    #[SerializedName('NumberOfInstallments')]
     private ?int $numberOfInstallments = null;
 
-    /**
-     * @SerializedName("InterestRate")
-     */
+    #[SerializedName('InterestRate')]
     private ?string $interestRate = null;
 
-    /**
-     * @SerializedName("InstallmentFee")
-     */
+    #[SerializedName('InstallmentFee')]
     private ?Amount $installmentFee = null;
 
-    /**
-     * @SerializedName("AnnualPercentageRate")
-     */
+    #[SerializedName('AnnualPercentageRate')]
     private ?string $annualPercentageRate = null;
 
-    /**
-     * @SerializedName("FirstInstallmentAmount")
-     */
+    #[SerializedName('FirstInstallmentAmount')]
     private ?Amount $firstInstallmentAmount = null;
 
-    /**
-     * @SerializedName("SubsequentInstallmentAmount")
-     */
+    #[SerializedName('SubsequentInstallmentAmount')]
     private ?Amount $subsequentInstallmentAmount = null;
 
-    /**
-     * @SerializedName("TotalAmountDue")
-     */
+    #[SerializedName('TotalAmountDue')]
     private ?Amount $totalAmountDue = null;
 
     public function getNumberOfInstallments(): ?int

--- a/lib/SaferpayJson/Response/Container/CustomPlan.php
+++ b/lib/SaferpayJson/Response/Container/CustomPlan.php
@@ -8,34 +8,22 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class CustomPlan
 {
-    /**
-     * @SerializedName("MinimumNumberOfInstallments")
-     */
+    #[SerializedName('MinimumNumberOfInstallments')]
     private ?int $minimumNumberOfInstallments = null;
 
-    /**
-     * @SerializedName("MaximumNumberOfInstallments")
-     */
+    #[SerializedName('MaximumNumberOfInstallments')]
     private ?int $maximumNumberOfInstallments = null;
 
-    /**
-     * @SerializedName("InterestRate")
-     */
+    #[SerializedName('InterestRate')]
     private ?string $interestRate = null;
 
-    /**
-     * @SerializedName("InstallmentFee")
-     */
+    #[SerializedName('InstallmentFee')]
     private ?Amount $installmentFee = null;
 
-    /**
-     * @SerializedName("AnnualPercentageRate")
-     */
+    #[SerializedName('AnnualPercentageRate')]
     private ?string $annualPercentageRate = null;
 
-    /**
-     * @SerializedName("TotalAmountDue")
-     */
+    #[SerializedName('TotalAmountDue')]
     private ?Amount $totalAmountDue = null;
 
     public function getMinimumNumberOfInstallments(): ?int

--- a/lib/SaferpayJson/Response/Container/Dcc.php
+++ b/lib/SaferpayJson/Response/Container/Dcc.php
@@ -8,19 +8,13 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Dcc
 {
-    /**
-     * @SerializedName("PayerAmount")
-     */
+    #[SerializedName('PayerAmount')]
     private ?Amount $payerAmount = null;
 
-    /**
-     * @SerializedName("Markup")
-     */
+    #[SerializedName('Markup')]
     private ?string $markup = null;
 
-    /**
-     * @SerializedName("ExchangeRate")
-     */
+    #[SerializedName('ExchangeRate')]
     private ?string $exchangeRate = null;
 
     public function getPayerAmount(): ?Amount

--- a/lib/SaferpayJson/Response/Container/DirectDebit.php
+++ b/lib/SaferpayJson/Response/Container/DirectDebit.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class DirectDebit
 {
-    /**
-     * @SerializedName("MandateId")
-     */
+    #[SerializedName('MandateId')]
     private ?string $mandateId = null;
 
-    /**
-     * @SerializedName("CreditorId")
-     */
+    #[SerializedName('CreditorId')]
     private ?string $creditorId = null;
 
     public function getMandateId(): ?string

--- a/lib/SaferpayJson/Response/Container/Error.php
+++ b/lib/SaferpayJson/Response/Container/Error.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Error
 {
-    /**
-     * @SerializedName("ErrorName")
-     */
+    #[SerializedName('ErrorName')]
     private ?string $errorName = null;
 
-    /**
-     * @SerializedName("ErrorMessage")
-     */
+    #[SerializedName('ErrorMessage')]
     private ?string $errorMessage = null;
 
     public function getErrorName(): ?string

--- a/lib/SaferpayJson/Response/Container/FraudPrevention.php
+++ b/lib/SaferpayJson/Response/Container/FraudPrevention.php
@@ -11,9 +11,7 @@ final class FraudPrevention
     public const APPROVED = 'APPROVED';
     public const CHALLENGED = 'CHALLENGED';
 
-    /**
-     * @SerializedName("Result")
-     */
+    #[SerializedName('Result')]
     private ?string $result = null;
 
     public function getResult(): ?string

--- a/lib/SaferpayJson/Response/Container/HolderAuthentication.php
+++ b/lib/SaferpayJson/Response/Container/HolderAuthentication.php
@@ -11,19 +11,13 @@ final class HolderAuthentication
     public const RESULT_OK = 'OK';
     public const RESULT_NOT_SUPPORTED = 'NOT_SUPPORTED';
 
-    /**
-     * @SerializedName("Result")
-     */
+    #[SerializedName('Result')]
     private ?string $result = null;
 
-    /**
-     * @SerializedName("Message")
-     */
+    #[SerializedName('Message')]
     private ?string $message = null;
 
-    /**
-     * @SerializedName("Xid")
-     */
+    #[SerializedName('Xid')]
     private ?string $xid = null;
 
     public function getResult(): ?string

--- a/lib/SaferpayJson/Response/Container/InstallmentPlan.php
+++ b/lib/SaferpayJson/Response/Container/InstallmentPlan.php
@@ -8,39 +8,25 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class InstallmentPlan
 {
-    /**
-     * @SerializedName("NumberOfInstallments")
-     */
+    #[SerializedName('NumberOfInstallments')]
     private ?int $numberOfInstallments = null;
 
-    /**
-     * @SerializedName("InterestRate")
-     */
+    #[SerializedName('InterestRate')]
     private ?string $interestRate = null;
 
-    /**
-     * @SerializedName("InstallmentFee")
-     */
+    #[SerializedName('InstallmentFee')]
     private ?Amount $installmentFee = null;
 
-    /**
-     * @SerializedName("AnnualPercentageRate")
-     */
+    #[SerializedName('AnnualPercentageRate')]
     private ?string $annualPercentageRate = null;
 
-    /**
-     * @SerializedName("FirstInstallmentAmount")
-     */
+    #[SerializedName('FirstInstallmentAmount')]
     private ?Amount $firstInstallmentAmount = null;
 
-    /**
-     * @SerializedName("SubsequentInstallmentAmount")
-     */
+    #[SerializedName('SubsequentInstallmentAmount')]
     private ?Amount $subsequentInstallmentAmount = null;
 
-    /**
-     * @SerializedName("TotalAmountDue")
-     */
+    #[SerializedName('TotalAmountDue')]
     private ?Amount $totalAmountDue = null;
 
     public function getNumberOfInstallments(): ?int

--- a/lib/SaferpayJson/Response/Container/Invoice.php
+++ b/lib/SaferpayJson/Response/Container/Invoice.php
@@ -9,21 +9,14 @@ use JMS\Serializer\Annotation\Type;
 
 final class Invoice
 {
-    /**
-     * @SerializedName("Payee")
-     */
+    #[SerializedName('Payee')]
     private ?Payee $payee = null;
 
-    /**
-     * @SerializedName("ReasonForTransfer")
-     */
+    #[SerializedName('ReasonForTransfer')]
     private ?string $reasonForTransfer = null;
 
-    /**
-     * @SerializedName("DueDate")
-     *
-     * @Type("DateTime<'Y-m-d'>")
-     */
+    #[SerializedName('DueDate')]
+    #[Type("DateTime<'Y-m-d'>")]
     private ?\DateTime $dueDate = null;
 
     public function getPayee(): ?Payee

--- a/lib/SaferpayJson/Response/Container/IssuerReference.php
+++ b/lib/SaferpayJson/Response/Container/IssuerReference.php
@@ -8,19 +8,13 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class IssuerReference
 {
-    /**
-     * @SerializedName("MastercardTLID")
-     */
+    #[SerializedName('MastercardTLID')]
     private ?string $mastercardTlid = null;
 
-    /**
-     * @SerializedName("TransactionStamp")
-     */
+    #[SerializedName('TransactionStamp')]
     private ?string $transactionStamp = null;
 
-    /**
-     * @SerializedName("SettlementDate")
-     */
+    #[SerializedName('SettlementDate')]
     private ?string $settlementDate = null;
 
     public function getMastercardTlid(): ?string

--- a/lib/SaferpayJson/Response/Container/Liability.php
+++ b/lib/SaferpayJson/Response/Container/Liability.php
@@ -8,24 +8,16 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Liability
 {
-    /**
-     * @SerializedName("LiabilityShift")
-     */
+    #[SerializedName('LiabilityShift')]
     private ?bool $liabilityShift = null;
 
-    /**
-     * @SerializedName("LiableEntity")
-     */
+    #[SerializedName('LiableEntity')]
     private ?string $liableEntity = null;
 
-    /**
-     * @SerializedName("ThreeDs")
-     */
+    #[SerializedName('ThreeDs')]
     private ?ThreeDs $threeDs = null;
 
-    /**
-     * @SerializedName("InPsd2Scope")
-     */
+    #[SerializedName('InPsd2Scope')]
     private ?string $inPsd2Scope = null;
 
     public function isLiabilityShift(): ?bool

--- a/lib/SaferpayJson/Response/Container/MastercardIssuerInstallments.php
+++ b/lib/SaferpayJson/Response/Container/MastercardIssuerInstallments.php
@@ -9,28 +9,17 @@ use JMS\Serializer\Annotation\Type;
 
 final class MastercardIssuerInstallments
 {
-    /**
-     * @var array<InstallmentPlan>
-     *
-     * @SerializedName("InstallmentPlans")
-     *
-     * @Type("array")
-     */
+    #[SerializedName('InstallmentPlans')]
+    #[Type('array')]
     private array $installmentPlans = [];
 
-    /**
-     * @SerializedName("CustomPlan")
-     */
+    #[SerializedName('CustomPlan')]
     private ?CustomPlan $customPlan = null;
 
-    /**
-     * @SerializedName("ReceiptFreeText")
-     */
+    #[SerializedName('ReceiptFreeText')]
     private ?string $receiptFreeText = null;
 
-    /**
-     * @SerializedName("ChosenPlan")
-     */
+    #[SerializedName('ChosenPlan')]
     private ?ChosenPlan $chosenPlan = null;
 
     public function getInstallmentPlans(): ?array

--- a/lib/SaferpayJson/Response/Container/PayPal.php
+++ b/lib/SaferpayJson/Response/Container/PayPal.php
@@ -8,19 +8,13 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class PayPal
 {
-    /**
-     * @SerializedName("PayerId")
-     */
+    #[SerializedName('PayerId')]
     private ?string $payerId = null;
 
-    /**
-     * @SerializedName("SellerProtectionStatus")
-     */
+    #[SerializedName('SellerProtectionStatus')]
     private ?string $sellerProtectionStatus = null;
 
-    /**
-     * @SerializedName("Email")
-     */
+    #[SerializedName('Email')]
     private ?string $email = null;
 
     public function getPayerId(): ?string

--- a/lib/SaferpayJson/Response/Container/Payee.php
+++ b/lib/SaferpayJson/Response/Container/Payee.php
@@ -8,24 +8,16 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Payee
 {
-    /**
-     * @SerializedName("Iban")
-     */
+    #[SerializedName('Iban')]
     private ?string $iban = null;
 
-    /**
-     * @SerializedName("HolderName")
-     */
+    #[SerializedName('HolderName')]
     private ?string $holderName = null;
 
-    /**
-     * @SerializedName("Bic")
-     */
+    #[SerializedName('Bic')]
     private ?string $bic = null;
 
-    /**
-     * @SerializedName("BankName")
-     */
+    #[SerializedName('BankName')]
     private ?string $bankName = null;
 
     public function getIban(): ?string

--- a/lib/SaferpayJson/Response/Container/Payer.php
+++ b/lib/SaferpayJson/Response/Container/Payer.php
@@ -8,29 +8,19 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Payer
 {
-    /**
-     * @SerializedName("Id")
-     */
+    #[SerializedName('Id')]
     private ?string $id = null;
 
-    /**
-     * @SerializedName("IpAddress")
-     */
+    #[SerializedName('IpAddress')]
     private ?string $ipAddress = null;
 
-    /**
-     * @SerializedName("IpLocation")
-     */
+    #[SerializedName('IpLocation')]
     private ?string $ipLocation = null;
 
-    /**
-     * @SerializedName("DeliveryAddress")
-     */
+    #[SerializedName('DeliveryAddress')]
     private ?Address $deliveryAddress = null;
 
-    /**
-     * @SerializedName("BillingAddress")
-     */
+    #[SerializedName('BillingAddress')]
     private ?Address $billingAddress = null;
 
     public function getId(): ?string

--- a/lib/SaferpayJson/Response/Container/PaymentMeans.php
+++ b/lib/SaferpayJson/Response/Container/PaymentMeans.php
@@ -8,34 +8,22 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class PaymentMeans
 {
-    /**
-     * @SerializedName("Brand")
-     */
+    #[SerializedName('Brand')]
     private ?Brand $brand = null;
 
-    /**
-     * @SerializedName("DisplayText")
-     */
+    #[SerializedName('DisplayText')]
     private ?string $displayText = null;
 
-    /**
-     * @SerializedName("Wallet")
-     */
+    #[SerializedName('Wallet')]
     private ?string $wallet = null;
 
-    /**
-     * @SerializedName("Card")
-     */
+    #[SerializedName('Card')]
     private ?Card $card = null;
 
-    /**
-     * @SerializedName("BankAccount")
-     */
+    #[SerializedName('BankAccount')]
     private ?BankAccount $bankAccount = null;
 
-    /**
-     * @SerializedName("PayPal")
-     */
+    #[SerializedName('PayPal')]
     private ?PayPal $payPal = null;
 
     public function getBrand(): ?Brand

--- a/lib/SaferpayJson/Response/Container/Redirect.php
+++ b/lib/SaferpayJson/Response/Container/Redirect.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Redirect
 {
-    /**
-     * @SerializedName("RedirectUrl")
-     */
+    #[SerializedName('RedirectUrl')]
     private ?string $redirectUrl = null;
 
-    /**
-     * @SerializedName("PaymentMeansRequired")
-     */
+    #[SerializedName('PaymentMeansRequired')]
     private ?bool $paymentMeansRequired = null;
 
     public function getRedirectUrl(): ?string

--- a/lib/SaferpayJson/Response/Container/RegisterAlias.php
+++ b/lib/SaferpayJson/Response/Container/RegisterAlias.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class RegisterAlias
 {
-    /**
-     * @SerializedName("Id")
-     */
+    #[SerializedName('Id')]
     private ?string $id = null;
 
-    /**
-     * @SerializedName("Lifetime")
-     */
+    #[SerializedName('Lifetime')]
     private ?int $lifetime = null;
 
     public function getId(): ?string

--- a/lib/SaferpayJson/Response/Container/RegistrationResult.php
+++ b/lib/SaferpayJson/Response/Container/RegistrationResult.php
@@ -8,24 +8,16 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class RegistrationResult
 {
-    /**
-     * @SerializedName("Success")
-     */
+    #[SerializedName('Success')]
     private ?bool $success = null;
 
-    /**
-     * @SerializedName("Alias")
-     */
+    #[SerializedName('Alias')]
     private ?Alias $alias = null;
 
-    /**
-     * @SerializedName("Error")
-     */
+    #[SerializedName('Error')]
     private ?Error $error = null;
 
-    /**
-     * @SerializedName("AuthenticationResult")
-     */
+    #[SerializedName('AuthenticationResult')]
     private ?AuthenticationResult $authenticationResult = null;
 
     public function isSuccess(): ?bool

--- a/lib/SaferpayJson/Response/Container/ResponseHeader.php
+++ b/lib/SaferpayJson/Response/Container/ResponseHeader.php
@@ -8,14 +8,10 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class ResponseHeader
 {
-    /**
-     * @SerializedName("SpecVersion")
-     */
+    #[SerializedName('SpecVersion')]
     private ?string $specVersion = null;
 
-    /**
-     * @SerializedName("RequestId")
-     */
+    #[SerializedName('RequestId')]
     private ?string $requestId = null;
 
     public function getSpecVersion(): ?string

--- a/lib/SaferpayJson/Response/Container/Risk.php
+++ b/lib/SaferpayJson/Response/Container/Risk.php
@@ -13,14 +13,10 @@ final class Risk
     public const BLOCKREASON_BLACKLIST_PAYMENT_MEANS = 'BLACKLIST_PAYMENT_MEANS';
     public const BLOCKREASON_BLACKLIST_PAYMENT_MEANS_ORIGIN = 'BLACKLIST_PAYMENT_MEANS_ORIGIN';
 
-    /**
-     * @SerializedName("BlockReason")
-     */
+    #[SerializedName('BlockReason')]
     private ?string $blockReason = null;
 
-    /**
-     * @SerializedName("IpLocation")
-     */
+    #[SerializedName('IpLocation')]
     private ?string $ipLocation = null;
 
     public function getBlockReason(): ?string

--- a/lib/SaferpayJson/Response/Container/SaferpayFields.php
+++ b/lib/SaferpayJson/Response/Container/SaferpayFields.php
@@ -8,9 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class SaferpayFields
 {
-    /**
-     * @SerializedName("Token")
-     */
+    #[SerializedName('Token')]
     private ?string $token = null;
 
     public function getToken(): ?string

--- a/lib/SaferpayJson/Response/Container/ThreeDs.php
+++ b/lib/SaferpayJson/Response/Container/ThreeDs.php
@@ -8,29 +8,19 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class ThreeDs
 {
-    /**
-     * @SerializedName("Authenticated")
-     */
+    #[SerializedName('Authenticated')]
     private ?bool $authenticated = null;
 
-    /**
-     * @SerializedName("LiabilityShift")
-     */
+    #[SerializedName('LiabilityShift')]
     private ?bool $liabilityShift = null;
 
-    /**
-     * @SerializedName("Xid")
-     */
+    #[SerializedName('Xid')]
     private ?string $xid = null;
 
-    /**
-     * @SerializedName("Version")
-     */
+    #[SerializedName('Version')]
     private ?string $version = null;
 
-    /**
-     * @SerializedName("AuthenticationType")
-     */
+    #[SerializedName('AuthenticationType')]
     private ?string $authenticationType = null;
 
     public function isAuthenticated(): ?bool

--- a/lib/SaferpayJson/Response/Container/TokenPan.php
+++ b/lib/SaferpayJson/Response/Container/TokenPan.php
@@ -8,19 +8,13 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class TokenPan
 {
-    /**
-     * @SerializedName("MaskedNumber")
-     */
+    #[SerializedName('MaskedNumber')]
     private ?string $maskedNumber = null;
 
-    /**
-     * @SerializedName("ExpYear")
-     */
+    #[SerializedName('ExpYear')]
     private ?int $expYear = null;
 
-    /**
-     * @SerializedName("ExpMonth")
-     */
+    #[SerializedName('ExpMonth')]
     private ?int $expMonth = null;
 
     public function getMaskedNumber(): ?string

--- a/lib/SaferpayJson/Response/Container/Tokenization.php
+++ b/lib/SaferpayJson/Response/Container/Tokenization.php
@@ -15,19 +15,13 @@ final class Tokenization
     public const STATUS_NOT_PERFORMED = 'NOT_PERFORMED';
     public const STATUS_DENIED_BY_SCHEME = 'DENIED_BY_SCHEME';
 
-    /**
-     * @SerializedName("Program")
-     */
+    #[SerializedName('Program')]
     private ?string $program = null;
 
-    /**
-     * @SerializedName("Status")
-     */
+    #[SerializedName('Status')]
     private ?string $status = null;
 
-    /**
-     * @SerializedName("TokenPan")
-     */
+    #[SerializedName('TokenPan')]
     private ?TokenizationTokenPan $tokenPan = null;
 
     public function getProgram(): ?string

--- a/lib/SaferpayJson/Response/Container/TokenizationTokenPan.php
+++ b/lib/SaferpayJson/Response/Container/TokenizationTokenPan.php
@@ -13,24 +13,16 @@ final class TokenizationTokenPan
     public const STATUS_DELETED = 'DELETED';
     public const STATUS_ACTIVATION_IN_PROGRESS = 'ACTIVATION_IN_PROGRESS';
 
-    /**
-     * @SerializedName("CardImageUrl")
-     */
+    #[SerializedName('CardImageUrl')]
     private ?string $cardImageUrl = null;
 
-    /**
-     * @SerializedName("ExpMonth")
-     */
+    #[SerializedName('ExpMonth')]
     private ?int $expMonth = null;
 
-    /**
-     * @SerializedName("ExpYear")
-     */
+    #[SerializedName('ExpYear')]
     private ?int $expYear = null;
 
-    /**
-     * @SerializedName("Status")
-     */
+    #[SerializedName('Status')]
     private ?string $status = null;
 
     public function getCardImageUrl(): ?string

--- a/lib/SaferpayJson/Response/Container/Transaction.php
+++ b/lib/SaferpayJson/Response/Container/Transaction.php
@@ -15,74 +15,46 @@ final class Transaction
     public const STATUS_CAPTURED = 'CAPTURED';
     public const STATUS_PENDING = 'PENDING';
 
-    /**
-     * @SerializedName("Type")
-     */
+    #[SerializedName('Type')]
     private ?string $type = null;
 
-    /**
-     * @SerializedName("Status")
-     */
+    #[SerializedName('Status')]
     private ?string $status = null;
 
-    /**
-     * @SerializedName("Id")
-     */
+    #[SerializedName('Id')]
     private ?string $id = null;
 
-    /**
-     * @SerializedName("CaptureId")
-     */
+    #[SerializedName('CaptureId')]
     private ?string $captureId = null;
 
-    /**
-     * @SerializedName("Date")
-     */
+    #[SerializedName('Date')]
     private ?string $date = null;
 
-    /**
-     * @SerializedName("Amount")
-     */
+    #[SerializedName('Amount')]
     private ?Amount $amount = null;
 
-    /**
-     * @SerializedName("OrderId")
-     */
+    #[SerializedName('OrderId')]
     private ?string $orderId = null;
 
-    /**
-     * @SerializedName("AcquirerName")
-     */
+    #[SerializedName('AcquirerName')]
     private ?string $acquirerName = null;
 
-    /**
-     * @SerializedName("AcquirerReference")
-     */
+    #[SerializedName('AcquirerReference')]
     private ?string $acquirerReference = null;
 
-    /**
-     * @SerializedName("SixTransactionReference")
-     */
+    #[SerializedName('SixTransactionReference')]
     private ?string $sixTransactionReference = null;
 
-    /**
-     * @SerializedName("ApprovalCode")
-     */
+    #[SerializedName('ApprovalCode')]
     private ?string $approvalCode = null;
 
-    /**
-     * @SerializedName("DirectDebit")
-     */
+    #[SerializedName('DirectDebit')]
     private ?DirectDebit $directDebit = null;
 
-    /**
-     * @SerializedName("Invoice")
-     */
+    #[SerializedName('Invoice')]
     private ?Invoice $invoice = null;
 
-    /**
-     * @SerializedName("IssuerReference")
-     */
+    #[SerializedName('IssuerReference')]
     private ?IssuerReference $issuerReference = null;
 
     public function getType(): ?string

--- a/lib/SaferpayJson/Response/ErrorResponse.php
+++ b/lib/SaferpayJson/Response/ErrorResponse.php
@@ -15,56 +15,35 @@ class ErrorResponse extends Response
     public const BEHAVIOUR_RETRY = 'RETRY';
     public const BEHAVIOUR_RETRY_LATER = 'RETRY_LATER';
 
-    /**
-     * @SerializedName("Risk")
-     */
+    #[SerializedName('Risk')]
     private ?Risk $risk = null;
 
-    /**
-     * @SerializedName("Behavior")
-     */
+    #[SerializedName('Behavior')]
     private ?string $behaviour = null;
 
-    /**
-     * @SerializedName("ErrorName")
-     */
+    #[SerializedName('ErrorName')]
     private ?string $errorName = null;
 
-    /**
-     * @SerializedName("ErrorMessage")
-     */
+    #[SerializedName('ErrorMessage')]
     private ?string $errorMessage = null;
 
-    /**
-     * @SerializedName("TransactionId")
-     */
+    #[SerializedName('TransactionId')]
     private ?string $transactionId = null;
 
-    /**
-     * @SerializedName("ErrorDetail")
-     *
-     * @Type("array")
-     */
+    #[SerializedName('ErrorDetail')]
+    #[Type('array')]
     private array $errorDetail = [];
 
-    /**
-     * @SerializedName("ProcessorName")
-     */
+    #[SerializedName('ProcessorName')]
     private ?string $processorName = null;
 
-    /**
-     * @SerializedName("ProcessorResult")
-     */
+    #[SerializedName('ProcessorResult')]
     private ?string $processorResult = null;
 
-    /**
-     * @SerializedName("ProcessorMessage")
-     */
+    #[SerializedName('ProcessorMessage')]
     private ?string $processorMessage = null;
 
-    /**
-     * @SerializedName("PayerMessage")
-     */
+    #[SerializedName('PayerMessage')]
     private ?string $payerMessage = null;
 
     public function getRisk(): ?Risk

--- a/lib/SaferpayJson/Response/PaymentPage/AssertResponse.php
+++ b/lib/SaferpayJson/Response/PaymentPage/AssertResponse.php
@@ -17,44 +17,28 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 final class AssertResponse extends Response
 {
-    /**
-     * @SerializedName("Transaction")
-     */
+    #[SerializedName('Transaction')]
     private ?Transaction $transaction = null;
 
-    /**
-     * @SerializedName("PaymentMeans")
-     */
+    #[SerializedName('PaymentMeans')]
     private ?PaymentMeans $paymentMeans = null;
 
-    /**
-     * @SerializedName("Payer")
-     */
+    #[SerializedName('Payer')]
     private ?Payer $payer = null;
 
-    /**
-     * @SerializedName("RegistrationResult")
-     */
+    #[SerializedName('RegistrationResult')]
     private ?RegistrationResult $registrationResult = null;
 
-    /**
-     * @SerializedName("Liability")
-     */
+    #[SerializedName('Liability')]
     private ?Liability $liability = null;
 
-    /**
-     * @SerializedName("Dcc")
-     */
+    #[SerializedName('Dcc')]
     private ?Dcc $dcc = null;
 
-    /**
-     * @SerializedName("MastercardIssuerInstallments")
-     */
+    #[SerializedName('MastercardIssuerInstallments')]
     private ?MastercardIssuerInstallments $mastercardIssuerInstallments = null;
 
-    /**
-     * @SerializedName("FraudPrevention")
-     */
+    #[SerializedName('FraudPrevention')]
     private ?FraudPrevention $fraudPrevention = null;
 
     public function getTransaction(): ?Transaction

--- a/lib/SaferpayJson/Response/PaymentPage/InitializeResponse.php
+++ b/lib/SaferpayJson/Response/PaymentPage/InitializeResponse.php
@@ -10,21 +10,14 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 final class InitializeResponse extends Response
 {
-    /**
-     * @SerializedName("Token")
-     */
+    #[SerializedName('Token')]
     private ?string $token = null;
 
-    /**
-     * @SerializedName("Expiration")
-     *
-     * @Type("DateTime<'Y-m-d\TH:i:s.uT'>")
-     */
+    #[SerializedName('Expiration')]
+    #[Type("DateTime<'Y-m-d\TH:i:s.uT'>")]
     private ?\DateTime $expiration = null;
 
-    /**
-     * @SerializedName("RedirectUrl")
-     */
+    #[SerializedName('RedirectUrl')]
     private ?string $redirectUrl = null;
 
     public function getToken(): ?string

--- a/lib/SaferpayJson/Response/Response.php
+++ b/lib/SaferpayJson/Response/Response.php
@@ -9,9 +9,7 @@ use Ticketpark\SaferpayJson\Response\Container\ResponseHeader;
 
 abstract class Response
 {
-    /**
-     * @SerializedName("ResponseHeader")
-     */
+    #[SerializedName('ResponseHeader')]
     protected ?ResponseHeader $responseHeader = null;
 
     public function getResponseHeader(): ?ResponseHeader

--- a/lib/SaferpayJson/Response/SecureCardData/AliasAssertInsertResponse.php
+++ b/lib/SaferpayJson/Response/SecureCardData/AliasAssertInsertResponse.php
@@ -13,24 +13,16 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 final class AliasAssertInsertResponse extends Response
 {
-    /**
-     * @SerializedName("Alias")
-     */
+    #[SerializedName('Alias')]
     private ?Alias $alias = null;
 
-    /**
-     * @SerializedName("PaymentMeans")
-     */
+    #[SerializedName('PaymentMeans')]
     private ?PaymentMeans $paymentMeans = null;
 
-    /**
-     * @SerializedName("CheckResult")
-     */
+    #[SerializedName('CheckResult')]
     private ?CheckResult $checkResult = null;
 
-    /**
-     * @SerializedName("Tokenization")
-     */
+    #[SerializedName('Tokenization')]
     private ?Tokenization $tokenization = null;
 
     public function getAlias(): ?Alias

--- a/lib/SaferpayJson/Response/SecureCardData/AliasInsertDirectResponse.php
+++ b/lib/SaferpayJson/Response/SecureCardData/AliasInsertDirectResponse.php
@@ -13,24 +13,16 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 final class AliasInsertDirectResponse extends Response
 {
-    /**
-     * @SerializedName("Alias")
-     */
+    #[SerializedName('Alias')]
     private ?Alias $alias = null;
 
-    /**
-     * @SerializedName("PaymentMeans")
-     */
+    #[SerializedName('PaymentMeans')]
     private ?PaymentMeans $paymentMeans = null;
 
-    /**
-     * @SerializedName("CheckResult")
-     */
+    #[SerializedName('CheckResult')]
     private ?CheckResult $checkResult = null;
 
-    /**
-     * @SerializedName("Tokenization")
-     */
+    #[SerializedName('Tokenization')]
     private ?Tokenization $tokenization = null;
 
     public function getAlias(): ?Alias

--- a/lib/SaferpayJson/Response/SecureCardData/AliasInsertResponse.php
+++ b/lib/SaferpayJson/Response/SecureCardData/AliasInsertResponse.php
@@ -11,26 +11,17 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 final class AliasInsertResponse extends Response
 {
-    /**
-     * @SerializedName("Token")
-     */
+    #[SerializedName('Token')]
     private ?string $token = null;
 
-    /**
-     * @SerializedName("Expiration")
-     *
-     * @Type("DateTime<'Y-m-d\TH:i:s.uT'>")
-     */
+    #[SerializedName('Expiration')]
+    #[Type("DateTime<'Y-m-d\TH:i:s.uT'>")]
     private ?\DateTime $expiration = null;
 
-    /**
-     * @SerializedName("RedirectRequired")
-     */
+    #[SerializedName('RedirectRequired')]
     private ?bool $redirectRequired = null;
 
-    /**
-     * @SerializedName("Redirect")
-     */
+    #[SerializedName('Redirect')]
     private ?Redirect $redirect = null;
 
     public function getToken(): ?string

--- a/lib/SaferpayJson/Response/SecureCardData/AliasUpdateResponse.php
+++ b/lib/SaferpayJson/Response/SecureCardData/AliasUpdateResponse.php
@@ -12,19 +12,13 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 final class AliasUpdateResponse extends Response
 {
-    /**
-     * @SerializedName("Alias")
-     */
+    #[SerializedName('Alias')]
     private ?Alias $alias = null;
 
-    /**
-     * @SerializedName("PaymentMeans")
-     */
+    #[SerializedName('PaymentMeans')]
     private ?PaymentMeans $paymentMeans = null;
 
-    /**
-     * @SerializedName("Tokenization")
-     */
+    #[SerializedName('Tokenization')]
     private ?Tokenization $tokenization = null;
 
     public function getAlias(): ?Alias

--- a/lib/SaferpayJson/Response/Transaction/AuthorizeDirectResponse.php
+++ b/lib/SaferpayJson/Response/Transaction/AuthorizeDirectResponse.php
@@ -15,34 +15,22 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 final class AuthorizeDirectResponse extends Response
 {
-    /**
-     * @SerializedName("Transaction")
-     */
+    #[SerializedName('Transaction')]
     private ?Transaction $transaction = null;
 
-    /**
-     * @SerializedName("PaymentMeans")
-     */
+    #[SerializedName('PaymentMeans')]
     private ?PaymentMeans $paymentMeans = null;
 
-    /**
-     * @SerializedName("RegisterAlias")
-     */
+    #[SerializedName('RegisterAlias')]
     private ?RegisterAlias $registerAlias = null;
 
-    /**
-     * @SerializedName("Payer")
-     */
+    #[SerializedName('Payer')]
     private ?Payer $payer = null;
 
-    /**
-     * @SerializedName("FraudPrevention")
-     */
+    #[SerializedName('FraudPrevention')]
     private ?FraudPrevention $fraudPrevention = null;
 
-    /**
-     * @SerializedName("Liability")
-     */
+    #[SerializedName('Liability')]
     private ?Liability $liability = null;
 
     public function getTransaction(): ?Transaction

--- a/lib/SaferpayJson/Response/Transaction/AuthorizeReferencedResponse.php
+++ b/lib/SaferpayJson/Response/Transaction/AuthorizeReferencedResponse.php
@@ -13,24 +13,16 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 final class AuthorizeReferencedResponse extends Response
 {
-    /**
-     * @SerializedName("Transaction")
-     */
+    #[SerializedName('Transaction')]
     private ?Transaction $transaction = null;
 
-    /**
-     * @SerializedName("PaymentMeans")
-     */
+    #[SerializedName('PaymentMeans')]
     private ?PaymentMeans $paymentMeans = null;
 
-    /**
-     * @SerializedName("Payer")
-     */
+    #[SerializedName('Payer')]
     private ?Payer $payer = null;
 
-    /**
-     * @SerializedName("Dcc")
-     */
+    #[SerializedName('Dcc')]
     private ?Dcc $dcc = null;
 
     public function getTransaction(): ?Transaction

--- a/lib/SaferpayJson/Response/Transaction/AuthorizeResponse.php
+++ b/lib/SaferpayJson/Response/Transaction/AuthorizeResponse.php
@@ -17,44 +17,28 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 final class AuthorizeResponse extends Response
 {
-    /**
-     * @SerializedName("Transaction")
-     */
+    #[SerializedName('Transaction')]
     private ?Transaction $transaction = null;
 
-    /**
-     * @SerializedName("PaymentMeans")
-     */
+    #[SerializedName('PaymentMeans')]
     private ?PaymentMeans $paymentMeans = null;
 
-    /**
-     * @SerializedName("Payer")
-     */
+    #[SerializedName('Payer')]
     private ?Payer $payer = null;
 
-    /**
-     * @SerializedName("RegistrationResult")
-     */
+    #[SerializedName('RegistrationResult')]
     private ?RegistrationResult $registrationResult = null;
 
-    /**
-     * @SerializedName("MastercardIssuerInstallments")
-     */
+    #[SerializedName('MastercardIssuerInstallments')]
     private ?MastercardIssuerInstallments $mastercardIssuerInstallments = null;
 
-    /**
-     * @SerializedName("FraudPrevention")
-     */
+    #[SerializedName('FraudPrevention')]
     private ?FraudPrevention $fraudPrevention = null;
 
-    /**
-     * @SerializedName("Liability")
-     */
+    #[SerializedName('Liability')]
     private ?Liability $liability = null;
 
-    /**
-     * @SerializedName("Dcc")
-     */
+    #[SerializedName('Dcc')]
     private ?Dcc $dcc = null;
 
     public function getTransaction(): ?Transaction

--- a/lib/SaferpayJson/Response/Transaction/CancelResponse.php
+++ b/lib/SaferpayJson/Response/Transaction/CancelResponse.php
@@ -10,21 +10,14 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 final class CancelResponse extends Response
 {
-    /**
-     * @SerializedName("TransactionId")
-     */
+    #[SerializedName('TransactionId')]
     private ?string $transactionId = null;
 
-    /**
-     * @SerializedName("OrderId")
-     */
+    #[SerializedName('OrderId')]
     private ?string $orderId = null;
 
-    /**
-     * @SerializedName("Date")
-     *
-     * @Type("DateTime<'Y-m-d\TH:i:s.uT'>")
-     */
+    #[SerializedName('Date')]
+    #[Type("DateTime<'Y-m-d\TH:i:s.uT'>")]
     private ?\DateTime $date = null;
 
     public function getTransactionId(): ?string

--- a/lib/SaferpayJson/Response/Transaction/CaptureResponse.php
+++ b/lib/SaferpayJson/Response/Transaction/CaptureResponse.php
@@ -14,31 +14,20 @@ final class CaptureResponse extends Response
     public const STATUS_PENDING = 'PENDING';
     public const STATUS_CAPTURED = 'CAPTURED';
 
-    /**
-     * @SerializedName("TransactionId")
-     */
+    #[SerializedName('TransactionId')]
     private ?string $transactionId = null;
 
-    /**
-     * @SerializedName("CaptureId")
-     */
+    #[SerializedName('CaptureId')]
     private ?string $captureId = null;
 
-    /**
-     * @SerializedName("Status")
-     */
+    #[SerializedName('Status')]
     private ?string $status = null;
 
-    /**
-     * @SerializedName("Date")
-     *
-     * @Type("DateTime<'Y-m-d\TH:i:s.uT'>")
-     */
+    #[SerializedName('Date')]
+    #[Type("DateTime<'Y-m-d\TH:i:s.uT'>")]
     private ?\DateTime $date = null;
 
-    /**
-     * @SerializedName("Invoice")
-     */
+    #[SerializedName('Invoice')]
     private ?Invoice $invoice = null;
 
     public function getTransactionId(): ?string

--- a/lib/SaferpayJson/Response/Transaction/InitializeResponse.php
+++ b/lib/SaferpayJson/Response/Transaction/InitializeResponse.php
@@ -11,31 +11,20 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 final class InitializeResponse extends Response
 {
-    /**
-     * @SerializedName("Token")
-     */
+    #[SerializedName('Token')]
     private ?string $token = null;
 
-    /**
-     * @SerializedName("Expiration")
-     *
-     * @Type("DateTime<'Y-m-d\TH:i:s.uT'>")
-     */
+    #[SerializedName('Expiration')]
+    #[Type("DateTime<'Y-m-d\TH:i:s.uT'>")]
     private ?\DateTime $expiration = null;
 
-    /**
-     * @SerializedName("LiabilityShift")
-     */
+    #[SerializedName('LiabilityShift')]
     private ?bool $liabilityShift = null;
 
-    /**
-     * @SerializedName("RedirectRequired")
-     */
+    #[SerializedName('RedirectRequired')]
     private ?bool $redirectRequired = null;
 
-    /**
-     * @SerializedName("Redirect")
-     */
+    #[SerializedName('Redirect')]
     private ?Redirect $redirect = null;
 
     public function getToken(): ?string

--- a/lib/SaferpayJson/Response/Transaction/InquireResponse.php
+++ b/lib/SaferpayJson/Response/Transaction/InquireResponse.php
@@ -14,29 +14,19 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 final class InquireResponse extends Response
 {
-    /**
-     * @SerializedName("Transaction")
-     */
+    #[SerializedName('Transaction')]
     private ?Transaction $transaction = null;
 
-    /**
-     * @SerializedName("PaymentMeans")
-     */
+    #[SerializedName('PaymentMeans')]
     private ?PaymentMeans $paymentMeans = null;
 
-    /**
-     * @SerializedName("Payer")
-     */
+    #[SerializedName('Payer')]
     private ?Payer $payer = null;
 
-    /**
-     * @SerializedName("Liability")
-     */
+    #[SerializedName('Liability')]
     private ?Liability $liability = null;
 
-    /**
-     * @SerializedName("Dcc")
-     */
+    #[SerializedName('Dcc')]
     private ?Dcc $dcc = null;
 
     public function getTransaction(): ?Transaction

--- a/lib/SaferpayJson/Response/Transaction/RefundResponse.php
+++ b/lib/SaferpayJson/Response/Transaction/RefundResponse.php
@@ -12,19 +12,13 @@ use Ticketpark\SaferpayJson\Response\Response;
 
 final class RefundResponse extends Response
 {
-    /**
-     * @SerializedName("Transaction")
-     */
+    #[SerializedName('Transaction')]
     private ?Transaction $transaction = null;
 
-    /**
-     * @SerializedName("PaymentMeans")
-     */
+    #[SerializedName('PaymentMeans')]
     private ?PaymentMeans $paymentMeans = null;
 
-    /**
-     * @SerializedName("Dcc")
-     */
+    #[SerializedName('Dcc')]
     private ?Dcc $dcc = null;
 
     public function getTransaction(): ?Transaction

--- a/lib/SaferpayJson/SerializerFactory.php
+++ b/lib/SaferpayJson/SerializerFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Ticketpark\SaferpayJson;
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use JMS\Serializer\SerializerBuilder;
 use JMS\Serializer\SerializerInterface;
 
@@ -15,13 +14,6 @@ final class SerializerFactory
     public static function get(): SerializerInterface
     {
         if (null === self::$serializer) {
-            // Support for doctrine/annotations 1.x
-            // @phpstan-ignore-next-line
-            if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
-                // @phpstan-ignore-next-line
-                AnnotationRegistry::registerLoader('class_exists');
-            }
-
             self::$serializer = SerializerBuilder::create()->build();
         }
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,9 +2,11 @@ parameters:
     level: 8
     paths:
         - lib
-    checkMissingIterableValueType: false
-    reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         -
-            message: '#Property [a-zA-Z0-9\\]+::\$[a-zA-Z0-9]+ is never written, only read.#'
+            identifier: property.unusedType
             path: lib/SaferpayJson/Response
+        -
+            identifier: missingType.iterableValue
+        -
+            identifier: return.unusedType

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd">
   <coverage>
     <include>
       <directory>./lib</directory>

--- a/rector.php
+++ b/rector.php
@@ -11,8 +11,7 @@ return RectorConfig::configure()
         __DIR__ . '/lib',
         __DIR__ . '/tests',
     ])
-    // uncomment to reach your current PHP version
-    // ->withPhpSets()
+    ->withPhpVersion(\Rector\ValueObject\PhpVersion::PHP_82)
     ->withImportNames(importShortClasses: false, removeUnusedImports: true)
     ->withRules([
         AddVoidReturnTypeWhereNoReturnRector::class,

--- a/tests/SaferpayJson/Tests/Request/CommonRequestTestCase.php
+++ b/tests/SaferpayJson/Tests/Request/CommonRequestTestCase.php
@@ -6,9 +6,11 @@ namespace Ticketpark\SaferpayJson\Tests\Request;
 
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use GuzzleHttp\Psr7\Utils as GuzzleUtils;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\StreamInterface;
 use Ticketpark\SaferpayJson\Request\Exception\SaferpayErrorException;
 use Ticketpark\SaferpayJson\Request\Exception\SaferpayException;
 use Ticketpark\SaferpayJson\Request\RequestConfig;
@@ -16,7 +18,7 @@ use Ticketpark\SaferpayJson\Response\ErrorResponse;
 use Ticketpark\SaferpayJson\Response\Response;
 use Ticketpark\SaferpayJson\SerializerFactory;
 
-abstract class CommonRequestTest extends TestCase
+abstract class CommonRequestTestCase extends TestCase
 {
     private ?bool $successful = null;
 
@@ -37,7 +39,7 @@ abstract class CommonRequestTest extends TestCase
         }
     }
 
-    public function getRequestConfigValidationParams(): array
+    public static function getRequestConfigValidationParams(): array
     {
         return [
             'first try' => [null, RequestConfig::MIN_RETRY_INDICATOR],
@@ -47,14 +49,12 @@ abstract class CommonRequestTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider getRequestConfigValidationParams
-     */
+    #[DataProvider('getRequestConfigValidationParams')]
     public function testRequestConfigValidation(
         ?string $requestId,
         int $retryIndicator,
-        ?string $expectedException = null): void
-    {
+        ?string $expectedException = null,
+    ): void {
         $config = new RequestConfig(
             'apiKey',
             'apiSecret',
@@ -102,7 +102,7 @@ abstract class CommonRequestTest extends TestCase
         return $initializer->execute();
     }
 
-    private function getClientMock(): MockObject
+    private function getClientMock(): MockObject&ClientInterface
     {
         $browser = $this->createMock(ClientInterface::class);
 
@@ -113,28 +113,18 @@ abstract class CommonRequestTest extends TestCase
         return $browser;
     }
 
-    private function getResponseMock(): MockObject
+    private function getResponseMock(): MockObject&GuzzleResponse
     {
-        $response = $this->getMockBuilder(GuzzleResponse::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods([
-                'getStatusCode',
-                'getBody',
-            ])
-            ->getMock();
+        $response = $this->createMock(GuzzleResponse::class);
 
-        $response->expects($this->any())
-            ->method('getStatusCode')
-            ->will($this->returnValue($this->successful ? 200 : 404));
+        $response->method('getStatusCode')
+            ->willReturn($this->successful ? 200 : 404);
 
-        if ($this->successful) {
-            $content = $this->getFakedApiResponse($this->successfulResponseClass);
-        } else {
-            $content = $this->getFakedApiResponse(ErrorResponse::class);
-        }
+        $content = $this->successful
+            ? $this->getFakedApiResponse($this->successfulResponseClass)
+            : $this->getFakedApiResponse(ErrorResponse::class);
 
-        $response->expects($this->any())
-            ->method('getBody')
+        $response->method('getBody')
             ->willReturn($this->getBodyContent($content));
 
         return $response;
@@ -147,7 +137,7 @@ abstract class CommonRequestTest extends TestCase
         return SerializerFactory::get()->serialize($response, 'json');
     }
 
-    private function getBodyContent(string $content)
+    private function getBodyContent(string $content): StreamInterface
     {
         return GuzzleUtils::streamFor($content);
     }

--- a/tests/SaferpayJson/Tests/Request/PaymentPage/AssertRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/PaymentPage/AssertRequestTest.php
@@ -6,9 +6,9 @@ namespace Ticketpark\SaferpayJson\Tests\Request\PaymentPage;
 
 use Ticketpark\SaferpayJson\Request\PaymentPage\AssertRequest;
 use Ticketpark\SaferpayJson\Response\PaymentPage\AssertResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class AssertRequestTest extends CommonRequestTest
+class AssertRequestTest extends CommonRequestTestCase
 {
     public function testSuccessfulResponse(): void
     {

--- a/tests/SaferpayJson/Tests/Request/PaymentPage/InitializeRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/PaymentPage/InitializeRequestTest.php
@@ -9,9 +9,9 @@ use Ticketpark\SaferpayJson\Request\Container\Payment;
 use Ticketpark\SaferpayJson\Request\Container\ReturnUrl;
 use Ticketpark\SaferpayJson\Request\PaymentPage\InitializeRequest;
 use Ticketpark\SaferpayJson\Response\PaymentPage\InitializeResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class InitializeRequestTest extends CommonRequestTest
+class InitializeRequestTest extends CommonRequestTestCase
 {
     public function testSuccessfulResponse(): void
     {

--- a/tests/SaferpayJson/Tests/Request/SecureCardData/AliasAssertInsertRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/SecureCardData/AliasAssertInsertRequestTest.php
@@ -6,9 +6,9 @@ namespace Ticketpark\SaferpayJson\Tests\Request\SecureCardData;
 
 use Ticketpark\SaferpayJson\Request\SecureCardData\AliasAssertInsertRequest;
 use Ticketpark\SaferpayJson\Response\SecureCardData\AliasAssertInsertResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class AliasAssertInsertRequestTest extends CommonRequestTest
+class AliasAssertInsertRequestTest extends CommonRequestTestCase
 {
     public function testSuccessfulResponse(): void
     {

--- a/tests/SaferpayJson/Tests/Request/SecureCardData/AliasDeleteRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/SecureCardData/AliasDeleteRequestTest.php
@@ -6,9 +6,9 @@ namespace Ticketpark\SaferpayJson\Tests\Request\SecureCardData;
 
 use Ticketpark\SaferpayJson\Request\SecureCardData\AliasDeleteRequest;
 use Ticketpark\SaferpayJson\Response\SecureCardData\AliasDeleteResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class AliasDeleteRequestTest extends CommonRequestTest
+class AliasDeleteRequestTest extends CommonRequestTestCase
 {
     public function testSuccessfulResponse(): void
     {

--- a/tests/SaferpayJson/Tests/Request/SecureCardData/AliasInsertDirectRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/SecureCardData/AliasInsertDirectRequestTest.php
@@ -7,9 +7,9 @@ namespace Ticketpark\SaferpayJson\Tests\Request\SecureCardData;
 use Ticketpark\SaferpayJson\Request\Container\PaymentMeans;
 use Ticketpark\SaferpayJson\Request\Container\RegisterAlias;
 use Ticketpark\SaferpayJson\Request\SecureCardData\AliasInsertDirectRequest;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class AliasInsertDirectRequestTest extends CommonRequestTest
+class AliasInsertDirectRequestTest extends CommonRequestTestCase
 {
     public function getInstance()
     {

--- a/tests/SaferpayJson/Tests/Request/SecureCardData/AliasInsertRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/SecureCardData/AliasInsertRequestTest.php
@@ -8,9 +8,9 @@ use Ticketpark\SaferpayJson\Request\Container\RegisterAlias;
 use Ticketpark\SaferpayJson\Request\Container\ReturnUrl;
 use Ticketpark\SaferpayJson\Request\SecureCardData\AliasInsertRequest;
 use Ticketpark\SaferpayJson\Response\SecureCardData\AliasInsertResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class AliasInsertRequestTest extends CommonRequestTest
+class AliasInsertRequestTest extends CommonRequestTestCase
 {
     public function testSuccessfulResponse(): void
     {

--- a/tests/SaferpayJson/Tests/Request/SecureCardData/AliasUpdateRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/SecureCardData/AliasUpdateRequestTest.php
@@ -9,9 +9,9 @@ use Ticketpark\SaferpayJson\Request\Container\UpdateAlias;
 use Ticketpark\SaferpayJson\Request\Container\UpdatePaymentMeans;
 use Ticketpark\SaferpayJson\Request\SecureCardData\AliasUpdateRequest;
 use Ticketpark\SaferpayJson\Response\SecureCardData\AliasUpdateResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class AliasUpdateRequestTest extends CommonRequestTest
+class AliasUpdateRequestTest extends CommonRequestTestCase
 {
     public function testSuccessfulResponse(): void
     {

--- a/tests/SaferpayJson/Tests/Request/Transaction/AuthorizeDirectRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/Transaction/AuthorizeDirectRequestTest.php
@@ -9,9 +9,9 @@ use Ticketpark\SaferpayJson\Request\Container\Payment;
 use Ticketpark\SaferpayJson\Request\Container\PaymentMeans;
 use Ticketpark\SaferpayJson\Request\Transaction\AuthorizeDirectRequest;
 use Ticketpark\SaferpayJson\Response\Transaction\AuthorizeDirectResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class AuthorizeDirectRequestTest extends CommonRequestTest
+class AuthorizeDirectRequestTest extends CommonRequestTestCase
 {
     public function testSuccessfulResponse(): void
     {

--- a/tests/SaferpayJson/Tests/Request/Transaction/AuthorizeReferencedRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/Transaction/AuthorizeReferencedRequestTest.php
@@ -9,9 +9,9 @@ use Ticketpark\SaferpayJson\Request\Container\Payment;
 use Ticketpark\SaferpayJson\Request\Container\TransactionReference;
 use Ticketpark\SaferpayJson\Request\Transaction\AuthorizeReferencedRequest;
 use Ticketpark\SaferpayJson\Response\Transaction\AuthorizeReferencedResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class AuthorizeReferencedRequestTest extends CommonRequestTest
+class AuthorizeReferencedRequestTest extends CommonRequestTestCase
 {
     public function testSuccessfulResponse(): void
     {

--- a/tests/SaferpayJson/Tests/Request/Transaction/AuthorizeRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/Transaction/AuthorizeRequestTest.php
@@ -6,9 +6,9 @@ namespace SaferpayJson\Tests\Request\Transaction;
 
 use Ticketpark\SaferpayJson\Request\Transaction\AuthorizeRequest;
 use Ticketpark\SaferpayJson\Response\Transaction\AuthorizeResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class AuthorizeRequestTest extends CommonRequestTest
+class AuthorizeRequestTest extends CommonRequestTestCase
 {
     protected function getInstance()
     {

--- a/tests/SaferpayJson/Tests/Request/Transaction/CancelRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/Transaction/CancelRequestTest.php
@@ -7,9 +7,9 @@ namespace Ticketpark\SaferpayJson\Tests\Request\Transaction;
 use Ticketpark\SaferpayJson\Request\Container\TransactionReference;
 use Ticketpark\SaferpayJson\Request\Transaction\CancelRequest;
 use Ticketpark\SaferpayJson\Response\Transaction\CancelResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class CancelRequestTest extends CommonRequestTest
+class CancelRequestTest extends CommonRequestTestCase
 {
     public function testSuccessfulResponse(): void
     {

--- a/tests/SaferpayJson/Tests/Request/Transaction/CaptureRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/Transaction/CaptureRequestTest.php
@@ -7,9 +7,9 @@ namespace Ticketpark\SaferpayJson\Tests\Request\Transaction;
 use Ticketpark\SaferpayJson\Request\Container\TransactionReference;
 use Ticketpark\SaferpayJson\Request\Transaction\CaptureRequest;
 use Ticketpark\SaferpayJson\Response\Transaction\CaptureResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class CaptureRequestTest extends CommonRequestTest
+class CaptureRequestTest extends CommonRequestTestCase
 {
     public function testSuccessfulResponse(): void
     {

--- a/tests/SaferpayJson/Tests/Request/Transaction/InitializeRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/Transaction/InitializeRequestTest.php
@@ -9,9 +9,9 @@ use Ticketpark\SaferpayJson\Request\Container\Payment;
 use Ticketpark\SaferpayJson\Request\Container\ReturnUrl;
 use Ticketpark\SaferpayJson\Request\Transaction\InitializeRequest;
 use Ticketpark\SaferpayJson\Response\Transaction\InitializeResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class InitializeRequestTest extends CommonRequestTest
+class InitializeRequestTest extends CommonRequestTestCase
 {
     protected function getInstance()
     {

--- a/tests/SaferpayJson/Tests/Request/Transaction/InquireRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/Transaction/InquireRequestTest.php
@@ -7,9 +7,9 @@ namespace SaferpayJson\Tests\Request\Transaction;
 use Ticketpark\SaferpayJson\Request\Container\TransactionReference;
 use Ticketpark\SaferpayJson\Request\Transaction\InquireRequest;
 use Ticketpark\SaferpayJson\Response\Transaction\InquireResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class InquireRequestTest extends CommonRequestTest
+class InquireRequestTest extends CommonRequestTestCase
 {
     public function testSuccessfulResponse(): void
     {

--- a/tests/SaferpayJson/Tests/Request/Transaction/RefundRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/Transaction/RefundRequestTest.php
@@ -9,9 +9,9 @@ use Ticketpark\SaferpayJson\Request\Container\CaptureReference;
 use Ticketpark\SaferpayJson\Request\Container\Refund;
 use Ticketpark\SaferpayJson\Request\Transaction\RefundRequest;
 use Ticketpark\SaferpayJson\Response\Transaction\RefundResponse;
-use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTest;
+use Ticketpark\SaferpayJson\Tests\Request\CommonRequestTestCase;
 
-class RefundRequestTest extends CommonRequestTest
+class RefundRequestTest extends CommonRequestTestCase
 {
     public function testSuccessfulResponse(): void
     {


### PR DESCRIPTION
Closes #125

- Raise minimum PHP requirement to `^8.2` (semver major breaking change)
- Remove `doctrine/annotations` and migrate all JMS `@SerializedName` / `@Type` docblocks to native PHP 8 attributes
- Drop `AnnotationRegistry` bootstrap from `SerializerFactory`
- Upgrade dev tooling to PHPUnit 11, PHPStan 2, and Rector 2; trim CI matrix to PHP 8.2–8.5
- Rename `CommonRequestTest` to `CommonRequestTestCase` for PHPUnit 11 compatibility

Made with [Cursor](https://cursor.com)