### PR TITLE
fix: Complete PHPUnit 11 upgrade

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory>./lib</directory>
-    </include>
-  </coverage>
   <testsuites>
     <testsuite name="SaferpayJsonApi">
       <directory>./tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory>./lib</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
Closes #122

- Migrate `phpunit.xml` from deprecated `<coverage>` to `<source>` configuration

The PHPUnit 11 dependency bump, test migration (`CommonRequestTestCase`, `#[DataProvider]`), and PHP 8.2 minimum were completed in #143.