### PR TITLE
Upgrade to PHPStan 2

### DIFF
--- a/lib/SaferpayJson/Request/Container/AddressForm.php
+++ b/lib/SaferpayJson/Request/Container/AddressForm.php
@@ -27,6 +27,7 @@ final class AddressForm
     #[SerializedName('AddressSource')]
     private string $addressSource;
 
+    /** @var list<string>|null */
     #[SerializedName('MandatoryFields')]
     private ?array $mandatoryFields = [];
 
@@ -40,11 +41,13 @@ final class AddressForm
         return $this->addressSource;
     }
 
+    /** @return list<string>|null */
     public function getMandatoryFields(): ?array
     {
         return $this->mandatoryFields;
     }
 
+    /** @param list<string>|null $mandatoryFields */
     public function setMandatoryFields(?array $mandatoryFields): self
     {
         $this->mandatoryFields = $mandatoryFields;

--- a/lib/SaferpayJson/Request/Container/Notification.php
+++ b/lib/SaferpayJson/Request/Container/Notification.php
@@ -8,6 +8,7 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Notification
 {
+    /** @var list<string>|null */
     #[SerializedName('MerchantEmails')]
     private ?array $merchantEmails = [];
 
@@ -23,11 +24,13 @@ final class Notification
     #[SerializedName('FailNotifyUrl')]
     private ?string $failNotifyUrl = null;
 
+    /** @return list<string>|null */
     public function getMerchantEmails(): ?array
     {
         return $this->merchantEmails;
     }
 
+    /** @param list<string>|null $merchantEmails */
     public function setMerchantEmails(?array $merchantEmails): self
     {
         $this->merchantEmails = $merchantEmails;

--- a/lib/SaferpayJson/Request/Container/Order.php
+++ b/lib/SaferpayJson/Request/Container/Order.php
@@ -8,14 +8,17 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Order
 {
+    /** @var list<OrderItem>|null */
     #[SerializedName('Items')]
     private ?array $items = [];
 
+    /** @return list<OrderItem>|null */
     public function getItems(): ?array
     {
         return $this->items;
     }
 
+    /** @param list<OrderItem>|null $items */
     public function setItems(?array $items): self
     {
         $this->items = $items;

--- a/lib/SaferpayJson/Request/Container/PendingNotification.php
+++ b/lib/SaferpayJson/Request/Container/PendingNotification.php
@@ -8,17 +8,20 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class PendingNotification
 {
+    /** @var list<string>|null */
     #[SerializedName('MerchantEmails')]
     private ?array $merchantEmails = [];
 
     #[SerializedName('NotifyUrl')]
     private ?string $notifyUrl = null;
 
+    /** @return list<string>|null */
     public function getMerchantEmails(): ?array
     {
         return $this->merchantEmails;
     }
 
+    /** @param list<string>|null $merchantEmails */
     public function setMerchantEmails(?array $merchantEmails): self
     {
         $this->merchantEmails = $merchantEmails;

--- a/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
@@ -73,6 +73,7 @@ final class InitializeRequest extends Request
     #[SerializedName('ConfigSet')]
     private ?string $configSet = null;
 
+    /** @var list<string>|null */
     #[SerializedName('PaymentMethods')]
     private ?array $paymentMethods = null;
 
@@ -82,6 +83,7 @@ final class InitializeRequest extends Request
     #[SerializedName('Authentication')]
     private ?Authentication $authentication = null;
 
+    /** @var list<string>|null */
     #[SerializedName('Wallets')]
     private ?array $wallets = null;
 
@@ -173,11 +175,13 @@ final class InitializeRequest extends Request
         return $this;
     }
 
+    /** @return list<string>|null */
     public function getPaymentMethods(): ?array
     {
         return $this->paymentMethods;
     }
 
+    /** @param list<string>|null $paymentMethods */
     public function setPaymentMethods(?array $paymentMethods): self
     {
         $this->paymentMethods = $paymentMethods;
@@ -209,11 +213,13 @@ final class InitializeRequest extends Request
         return $this;
     }
 
+    /** @return list<string>|null */
     public function getWallets(): ?array
     {
         return $this->wallets;
     }
 
+    /** @param list<string>|null $wallets */
     public function setWallets(?array $wallets): self
     {
         $this->wallets = $wallets;

--- a/lib/SaferpayJson/Request/Request.php
+++ b/lib/SaferpayJson/Request/Request.php
@@ -100,6 +100,7 @@ abstract class Request
         return $this->requestConfig->getRootUrl().$this->getApiPath();
     }
 
+    /** @return array<string, string> */
     private function getHeaders(): array
     {
         return [

--- a/lib/SaferpayJson/Request/SecureCardData/AliasInsertRequest.php
+++ b/lib/SaferpayJson/Request/SecureCardData/AliasInsertRequest.php
@@ -58,6 +58,7 @@ final class AliasInsertRequest extends Request
     #[SerializedName('Check')]
     private ?Check $check = null;
 
+    /** @var list<string>|null */
     #[SerializedName('PaymentMethods')]
     private ?array $paymentMethods = null;
 
@@ -155,11 +156,13 @@ final class AliasInsertRequest extends Request
         return $this;
     }
 
+    /** @return list<string>|null */
     public function getPaymentMethods(): ?array
     {
         return $this->paymentMethods;
     }
 
+    /** @param list<string>|null $paymentMethods */
     public function setPaymentMethods(?array $paymentMethods): self
     {
         $this->paymentMethods = $paymentMethods;

--- a/lib/SaferpayJson/Request/Transaction/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/InitializeRequest.php
@@ -65,6 +65,7 @@ final class InitializeRequest extends Request
     #[SerializedName('Styling')]
     private ?Styling $styling = null;
 
+    /** @var list<string>|null */
     #[SerializedName('PaymentMethods')]
     private ?array $paymentMethods = null;
 
@@ -139,6 +140,7 @@ final class InitializeRequest extends Request
         return $this;
     }
 
+    /** @param list<string>|null $paymentMethods */
     public function setPaymentMethods(?array $paymentMethods): self
     {
         $this->paymentMethods = $paymentMethods;
@@ -214,6 +216,7 @@ final class InitializeRequest extends Request
         return $this->styling;
     }
 
+    /** @return list<string>|null */
     public function getPaymentMethods(): ?array
     {
         return $this->paymentMethods;

--- a/lib/SaferpayJson/Response/Container/MastercardIssuerInstallments.php
+++ b/lib/SaferpayJson/Response/Container/MastercardIssuerInstallments.php
@@ -9,8 +9,9 @@ use JMS\Serializer\Annotation\Type;
 
 final class MastercardIssuerInstallments
 {
+    /** @var list<InstallmentPlan> */
     #[SerializedName('InstallmentPlans')]
-    #[Type('array')]
+    #[Type('array<Ticketpark\SaferpayJson\Response\Container\InstallmentPlan>')]
     private array $installmentPlans = [];
 
     #[SerializedName('CustomPlan')]
@@ -22,7 +23,8 @@ final class MastercardIssuerInstallments
     #[SerializedName('ChosenPlan')]
     private ?ChosenPlan $chosenPlan = null;
 
-    public function getInstallmentPlans(): ?array
+    /** @return list<InstallmentPlan> */
+    public function getInstallmentPlans(): array
     {
         return $this->installmentPlans;
     }

--- a/lib/SaferpayJson/Response/ErrorResponse.php
+++ b/lib/SaferpayJson/Response/ErrorResponse.php
@@ -30,6 +30,7 @@ class ErrorResponse extends Response
     #[SerializedName('TransactionId')]
     private ?string $transactionId = null;
 
+    /** @var array<string, mixed> */
     #[SerializedName('ErrorDetail')]
     #[Type('array')]
     private array $errorDetail = [];
@@ -71,6 +72,7 @@ class ErrorResponse extends Response
         return $this->transactionId;
     }
 
+    /** @return array<string, mixed>|null */
     public function getErrorDetail(): ?array
     {
         return $this->errorDetail;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,4 @@ parameters:
             identifier: property.unusedType
             path: lib/SaferpayJson/Response
         -
-            identifier: missingType.iterableValue
-        -
             identifier: return.unusedType


### PR DESCRIPTION
Closes #123

- Remove global `missingType.iterableValue` suppression from `phpstan.neon`
- Add iterable value PHPDoc types for array properties and methods across request/response classes
- Tighten `MastercardIssuerInstallments::getInstallmentPlans()` return type from `?array` to `array`

Made with [Cursor](https://cursor.com)