### PR TITLE
feat: Use constructor property promotion and readonly properties

### DIFF
--- a/lib/SaferpayJson/Request/Container/A2a.php
+++ b/lib/SaferpayJson/Request/Container/A2a.php
@@ -6,14 +6,12 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class A2a
+final readonly class A2a
 {
-    #[SerializedName('AccountHolderName')]
-    private string $accountHolderName;
-
-    public function __construct(string $accountHolderName)
-    {
-        $this->accountHolderName = $accountHolderName;
+    public function __construct(
+        #[SerializedName('AccountHolderName')]
+        private string $accountHolderName,
+    ) {
     }
 
     public function getAccountHolderName(): string

--- a/lib/SaferpayJson/Request/Container/AddressForm.php
+++ b/lib/SaferpayJson/Request/Container/AddressForm.php
@@ -24,16 +24,14 @@ final class AddressForm
     public const ADDRESS_SOURCE_SAFERPAY = 'SAFERPAY';
     public const ADDRESS_SOURCE_PREFER_PAYMENTMETHOD = 'PREFER_PAYMENTMETHOD';
 
-    #[SerializedName('AddressSource')]
-    private string $addressSource;
-
     /** @var list<string>|null */
     #[SerializedName('MandatoryFields')]
     private ?array $mandatoryFields = [];
 
-    public function __construct(string $addressSource)
-    {
-        $this->addressSource = $addressSource;
+    public function __construct(
+        #[SerializedName('AddressSource')]
+        private readonly string $addressSource,
+    ) {
     }
 
     public function getAddressSource(): string

--- a/lib/SaferpayJson/Request/Container/Alias.php
+++ b/lib/SaferpayJson/Request/Container/Alias.php
@@ -8,15 +8,13 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Alias
 {
-    #[SerializedName('Id')]
-    private string $id;
-
     #[SerializedName('VerificationCode')]
     private ?string $verificationCode = null;
 
-    public function __construct(string $id)
-    {
-        $this->id = $id;
+    public function __construct(
+        #[SerializedName('Id')]
+        private readonly string $id,
+    ) {
     }
 
     public function getId(): string

--- a/lib/SaferpayJson/Request/Container/Amount.php
+++ b/lib/SaferpayJson/Request/Container/Amount.php
@@ -6,18 +6,14 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class Amount
+final readonly class Amount
 {
-    #[SerializedName('Value')]
-    private int $value;
-
-    #[SerializedName('CurrencyCode')]
-    private string $currencyCode;
-
-    public function __construct(int $value, string $currencyCode)
-    {
-        $this->value = $value;
-        $this->currencyCode = $currencyCode;
+    public function __construct(
+        #[SerializedName('Value')]
+        private int $value,
+        #[SerializedName('CurrencyCode')]
+        private string $currencyCode,
+    ) {
     }
 
     public function getValue(): int

--- a/lib/SaferpayJson/Request/Container/ApplePay.php
+++ b/lib/SaferpayJson/Request/Container/ApplePay.php
@@ -6,14 +6,12 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class ApplePay
+final readonly class ApplePay
 {
-    #[SerializedName('PaymentToken')]
-    private string $paymentToken;
-
-    public function __construct(string $paymentToken)
-    {
-        $this->paymentToken = $paymentToken;
+    public function __construct(
+        #[SerializedName('PaymentToken')]
+        private string $paymentToken,
+    ) {
     }
 
     public function getPaymentToken(): string

--- a/lib/SaferpayJson/Request/Container/Attachment.php
+++ b/lib/SaferpayJson/Request/Container/Attachment.php
@@ -6,18 +6,14 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class Attachment
+final readonly class Attachment
 {
-    #[SerializedName('ContentType')]
-    private string $contentType;
-
-    #[SerializedName('Body')]
-    private string $body;
-
-    public function __construct(string $contentType, string $body)
-    {
-        $this->contentType = $contentType;
-        $this->body = $body;
+    public function __construct(
+        #[SerializedName('ContentType')]
+        private string $contentType,
+        #[SerializedName('Body')]
+        private string $body,
+    ) {
     }
 
     public function getContentType(): string

--- a/lib/SaferpayJson/Request/Container/BankAccount.php
+++ b/lib/SaferpayJson/Request/Container/BankAccount.php
@@ -8,9 +8,6 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class BankAccount
 {
-    #[SerializedName('Iban')]
-    private string $iban;
-
     #[SerializedName('HolderName')]
     private ?string $holderName = null;
 
@@ -20,9 +17,10 @@ final class BankAccount
     #[SerializedName('BankName')]
     private ?string $bankName = null;
 
-    public function __construct(string $iban)
-    {
-        $this->iban = $iban;
+    public function __construct(
+        #[SerializedName('Iban')]
+        private readonly string $iban,
+    ) {
     }
 
     public function getIban(): string

--- a/lib/SaferpayJson/Request/Container/ChosenPlan.php
+++ b/lib/SaferpayJson/Request/Container/ChosenPlan.php
@@ -8,9 +8,6 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class ChosenPlan
 {
-    #[SerializedName('NumberOfInstallments')]
-    private int $numberOfInstallments;
-
     #[SerializedName('InterestRate')]
     private ?string $interestRate = null;
 
@@ -29,9 +26,10 @@ final class ChosenPlan
     #[SerializedName('TotalAmountDue')]
     private ?Amount $totalAmountDue = null;
 
-    public function __construct(int $numberOfInstallments)
-    {
-        $this->numberOfInstallments = $numberOfInstallments;
+    public function __construct(
+        #[SerializedName('NumberOfInstallments')]
+        private readonly int $numberOfInstallments,
+    ) {
     }
 
     public function getNumberOfInstallments(): int

--- a/lib/SaferpayJson/Request/Container/DccReference.php
+++ b/lib/SaferpayJson/Request/Container/DccReference.php
@@ -6,18 +6,14 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class DccReference
+final readonly class DccReference
 {
-    #[SerializedName('SelectedCurrencyCode')]
-    private string $selectedCurrencyCode;
-
-    #[SerializedName('Token')]
-    private string $token;
-
-    public function __construct(string $selectedCurrencyCode, string $token)
-    {
-        $this->selectedCurrencyCode = $selectedCurrencyCode;
-        $this->token = $token;
+    public function __construct(
+        #[SerializedName('SelectedCurrencyCode')]
+        private string $selectedCurrencyCode,
+        #[SerializedName('Token')]
+        private string $token,
+    ) {
     }
 
     public function getSelectedCurrencyCode(): string

--- a/lib/SaferpayJson/Request/Container/ExternalThreeDS.php
+++ b/lib/SaferpayJson/Request/Container/ExternalThreeDS.php
@@ -22,56 +22,29 @@ final class ExternalThreeDS
     public const TRANS_STATUS_U = 'U';
     public const TRANS_STATUS_I = 'I';
 
-    #[SerializedName('AcsTransId')]
-    private string $acsTransId;
-
     #[SerializedName('AuthenticationMode')]
     private ?string $authenticationMode = null;
 
-    #[SerializedName('AuthenticationTime')]
-    private string $authenticationTime;
-
-    #[SerializedName('AuthenticationValue')]
-    private string $authenticationValue;
-
-    #[SerializedName('DsTransId')]
-    private string $dsTransId;
-
-    #[SerializedName('Eci')]
-    private string $eci;
-
-    #[SerializedName('Scheme')]
-    private string $scheme;
-
-    #[SerializedName('ThreeDsFullVersion')]
-    private string $threeDsFullVersion;
-
-    #[SerializedName('ThreeDSServerTransId')]
-    private string $threeDSServerTransId;
-
-    #[SerializedName('TransStatus')]
-    private string $transStatus;
-
     public function __construct(
-        string $acsTransId,
-        string $authenticationTime,
-        string $authenticationValue,
-        string $dsTransId,
-        string $eci,
-        string $scheme,
-        string $threeDsFullVersion,
-        string $threeDSServerTransId,
-        string $transStatus,
+        #[SerializedName('AcsTransId')]
+        private readonly string $acsTransId,
+        #[SerializedName('AuthenticationTime')]
+        private readonly string $authenticationTime,
+        #[SerializedName('AuthenticationValue')]
+        private readonly string $authenticationValue,
+        #[SerializedName('DsTransId')]
+        private readonly string $dsTransId,
+        #[SerializedName('Eci')]
+        private readonly string $eci,
+        #[SerializedName('Scheme')]
+        private readonly string $scheme,
+        #[SerializedName('ThreeDsFullVersion')]
+        private readonly string $threeDsFullVersion,
+        #[SerializedName('ThreeDSServerTransId')]
+        private readonly string $threeDSServerTransId,
+        #[SerializedName('TransStatus')]
+        private readonly string $transStatus,
     ) {
-        $this->acsTransId = $acsTransId;
-        $this->authenticationTime = $authenticationTime;
-        $this->authenticationValue = $authenticationValue;
-        $this->dsTransId = $dsTransId;
-        $this->eci = $eci;
-        $this->scheme = $scheme;
-        $this->threeDsFullVersion = $threeDsFullVersion;
-        $this->threeDSServerTransId = $threeDSServerTransId;
-        $this->transStatus = $transStatus;
     }
 
     public function getAcsTransId(): string

--- a/lib/SaferpayJson/Request/Container/ForeignRetailer.php
+++ b/lib/SaferpayJson/Request/Container/ForeignRetailer.php
@@ -11,9 +11,6 @@ final class ForeignRetailer
     #[SerializedName('City')]
     private ?string $city = null;
 
-    #[SerializedName('CountryCode')]
-    private string $countryCode;
-
     #[SerializedName('Name')]
     private ?string $name = null;
 
@@ -23,9 +20,10 @@ final class ForeignRetailer
     #[SerializedName('Zip')]
     private ?string $zip = null;
 
-    public function __construct(string $countryCode)
-    {
-        $this->countryCode = $countryCode;
+    public function __construct(
+        #[SerializedName('CountryCode')]
+        private readonly string $countryCode,
+    ) {
     }
 
     public function getCity(): ?string

--- a/lib/SaferpayJson/Request/Container/GooglePay.php
+++ b/lib/SaferpayJson/Request/Container/GooglePay.php
@@ -6,14 +6,12 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class GooglePay
+final readonly class GooglePay
 {
-    #[SerializedName('PaymentToken')]
-    private string $paymentToken;
-
-    public function __construct(string $paymentToken)
-    {
-        $this->paymentToken = $paymentToken;
+    public function __construct(
+        #[SerializedName('PaymentToken')]
+        private string $paymentToken,
+    ) {
     }
 
     public function getPaymentToken(): string

--- a/lib/SaferpayJson/Request/Container/Ideal.php
+++ b/lib/SaferpayJson/Request/Container/Ideal.php
@@ -6,14 +6,12 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class Ideal
+final readonly class Ideal
 {
-    #[SerializedName('IssuerId')]
-    private string $issuerId;
-
-    public function __construct(string $issuerId)
-    {
-        $this->issuerId = $issuerId;
+    public function __construct(
+        #[SerializedName('IssuerId')]
+        private string $issuerId,
+    ) {
     }
 
     public function getIssuerId(): string

--- a/lib/SaferpayJson/Request/Container/Installment.php
+++ b/lib/SaferpayJson/Request/Container/Installment.php
@@ -6,14 +6,12 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class Installment
+final readonly class Installment
 {
-    #[SerializedName('Initial')]
-    private bool $initial;
-
-    public function __construct(bool $initial)
-    {
-        $this->initial = $initial;
+    public function __construct(
+        #[SerializedName('Initial')]
+        private bool $initial,
+    ) {
     }
 
     public function isInitial(): bool

--- a/lib/SaferpayJson/Request/Container/IssuerReference.php
+++ b/lib/SaferpayJson/Request/Container/IssuerReference.php
@@ -8,15 +8,13 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class IssuerReference
 {
-    #[SerializedName('TransactionStamp')]
-    private string $transactionStamp;
-
     #[SerializedName('SettlementDate')]
     private ?string $settlementDate = null;
 
-    public function __construct(string $transactionStamp)
-    {
-        $this->transactionStamp = $transactionStamp;
+    public function __construct(
+        #[SerializedName('TransactionStamp')]
+        private readonly string $transactionStamp,
+    ) {
     }
 
     public function getTransactionStamp(): string

--- a/lib/SaferpayJson/Request/Container/Klarna.php
+++ b/lib/SaferpayJson/Request/Container/Klarna.php
@@ -6,14 +6,12 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class Klarna
+final readonly class Klarna
 {
-    #[SerializedName('Attachment')]
-    private Attachment $attachment;
-
-    public function __construct(Attachment $attachment)
-    {
-        $this->attachment = $attachment;
+    public function __construct(
+        #[SerializedName('Attachment')]
+        private Attachment $attachment,
+    ) {
     }
 
     public function getAttachment(): Attachment

--- a/lib/SaferpayJson/Request/Container/Marketplace.php
+++ b/lib/SaferpayJson/Request/Container/Marketplace.php
@@ -8,9 +8,6 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Marketplace
 {
-    #[SerializedName('SubmerchantId')]
-    private string $submerchantId;
-
     #[SerializedName('Fee')]
     private ?Amount $fee = null;
 
@@ -20,9 +17,10 @@ final class Marketplace
     #[SerializedName('ForeignRetailer')]
     private ?ForeignRetailer $foreignRetailer = null;
 
-    public function __construct(string $submerchantId)
-    {
-        $this->submerchantId = $submerchantId;
+    public function __construct(
+        #[SerializedName('SubmerchantId')]
+        private readonly string $submerchantId,
+    ) {
     }
 
     public function getSubmerchantId(): string

--- a/lib/SaferpayJson/Request/Container/Payment.php
+++ b/lib/SaferpayJson/Request/Container/Payment.php
@@ -8,9 +8,6 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Payment
 {
-    #[SerializedName('Amount')]
-    private Amount $amount;
-
     #[SerializedName('OrderId')]
     private ?string $orderId = null;
 
@@ -32,21 +29,15 @@ final class Payment
     #[SerializedName('Installment')]
     private ?Installment $installment = null;
 
-    public function __construct(Amount $amount)
-    {
-        $this->amount = $amount;
+    public function __construct(
+        #[SerializedName('Amount')]
+        private readonly Amount $amount,
+    ) {
     }
 
     public function getAmount(): Amount
     {
         return $this->amount;
-    }
-
-    public function setAmount(Amount $amount): self
-    {
-        $this->amount = $amount;
-
-        return $this;
     }
 
     public function getOrderId(): ?string

--- a/lib/SaferpayJson/Request/Container/Recurring.php
+++ b/lib/SaferpayJson/Request/Container/Recurring.php
@@ -6,14 +6,12 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class Recurring
+final readonly class Recurring
 {
-    #[SerializedName('Initial')]
-    private bool $initial;
-
-    public function __construct(bool $initial = true)
-    {
-        $this->initial = $initial;
+    public function __construct(
+        #[SerializedName('Initial')]
+        private bool $initial = true,
+    ) {
     }
 
     public function isInitial(): bool

--- a/lib/SaferpayJson/Request/Container/RedirectNotifyUrls.php
+++ b/lib/SaferpayJson/Request/Container/RedirectNotifyUrls.php
@@ -6,18 +6,14 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class RedirectNotifyUrls
+final readonly class RedirectNotifyUrls
 {
-    #[SerializedName('Success')]
-    private string $success;
-
-    #[SerializedName('Fail')]
-    private string $fail;
-
-    public function __construct(string $success, string $fail)
-    {
-        $this->success = $success;
-        $this->fail = $fail;
+    public function __construct(
+        #[SerializedName('Success')]
+        private string $success,
+        #[SerializedName('Fail')]
+        private string $fail,
+    ) {
     }
 
     public function getSuccess(): string

--- a/lib/SaferpayJson/Request/Container/Refund.php
+++ b/lib/SaferpayJson/Request/Container/Refund.php
@@ -8,9 +8,6 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Refund
 {
-    #[SerializedName('Amount')]
-    private ?Amount $amount;
-
     #[SerializedName('OrderId')]
     private ?string $orderId = null;
 
@@ -23,21 +20,15 @@ final class Refund
     #[SerializedName('RestrictRefundAmountToCapturedAmount')]
     private ?bool $restrictRefundAmountToCapturedAmount = null;
 
-    public function __construct(?Amount $amount)
-    {
-        $this->amount = $amount;
+    public function __construct(
+        #[SerializedName('Amount')]
+        private readonly ?Amount $amount,
+    ) {
     }
 
     public function getAmount(): ?Amount
     {
         return $this->amount;
-    }
-
-    public function setAmount(?Amount $amount): self
-    {
-        $this->amount = $amount;
-
-        return $this;
     }
 
     public function getOrderId(): ?string

--- a/lib/SaferpayJson/Request/Container/RegisterAlias.php
+++ b/lib/SaferpayJson/Request/Container/RegisterAlias.php
@@ -12,18 +12,16 @@ final class RegisterAlias
     public const ID_GENERATOR_RANDOM = 'RANDOM';
     public const ID_GENERATOR_RANDOM_UNIQUE = 'RANDOM_UNIQUE';
 
-    #[SerializedName('IdGenerator')]
-    private string $idGenerator;
-
     #[SerializedName('Id')]
     private ?string $id = null;
 
     #[SerializedName('Lifetime')]
     private ?int $lifetime = null;
 
-    public function __construct(string $idGenerator)
-    {
-        $this->idGenerator = $idGenerator;
+    public function __construct(
+        #[SerializedName('IdGenerator')]
+        private readonly string $idGenerator,
+    ) {
     }
 
     public function getIdGenerator(): string

--- a/lib/SaferpayJson/Request/Container/RequestHeader.php
+++ b/lib/SaferpayJson/Request/Container/RequestHeader.php
@@ -12,30 +12,20 @@ final class RequestHeader
     #[SerializedName('SpecVersion')]
     private string $specVersion = '1.52';
 
-    #[SerializedName('CustomerId')]
-    private string $customerId;
-
     #[SerializedName('RequestId')]
-    private ?string $requestId;
-
-    #[SerializedName('RetryIndicator')]
-    private int $retryIndicator;
+    private readonly ?string $requestId;
 
     #[SerializedName('ClientInfo')]
     private ?ClientInfo $clientInfo = null;
 
     public function __construct(
-        string $customerId,
+        #[SerializedName('CustomerId')]
+        private readonly string $customerId,
         ?string $requestId = null,
-        int $retryIndicator = RequestConfig::MIN_RETRY_INDICATOR,
+        #[SerializedName('RetryIndicator')]
+        private readonly int $retryIndicator = RequestConfig::MIN_RETRY_INDICATOR,
     ) {
-        $this->customerId = $customerId;
-        $this->requestId = $requestId;
-        $this->retryIndicator = $retryIndicator;
-
-        if (null === $requestId && 0 === $retryIndicator) {
-            $this->requestId = uniqid();
-        }
+        $this->requestId = null === $requestId && 0 === $retryIndicator ? uniqid() : $requestId;
     }
 
     public function getSpecVersion(): string

--- a/lib/SaferpayJson/Request/Container/ReturnUrl.php
+++ b/lib/SaferpayJson/Request/Container/ReturnUrl.php
@@ -6,14 +6,12 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class ReturnUrl
+final readonly class ReturnUrl
 {
-    #[SerializedName('Url')]
-    private string $url;
-
-    public function __construct(string $url)
-    {
-        $this->url = $url;
+    public function __construct(
+        #[SerializedName('Url')]
+        private string $url,
+    ) {
     }
 
     public function getUrl(): string

--- a/lib/SaferpayJson/Request/Container/SaferpayFields.php
+++ b/lib/SaferpayJson/Request/Container/SaferpayFields.php
@@ -6,14 +6,12 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class SaferpayFields
+final readonly class SaferpayFields
 {
-    #[SerializedName('Token')]
-    private string $token;
-
-    public function __construct(string $token)
-    {
-        $this->token = $token;
+    public function __construct(
+        #[SerializedName('Token')]
+        private string $token,
+    ) {
     }
 
     public function getToken(): ?string

--- a/lib/SaferpayJson/Request/Container/SchemeToken.php
+++ b/lib/SaferpayJson/Request/Container/SchemeToken.php
@@ -16,31 +16,21 @@ final class SchemeToken
     public const TOKEN_TYPE_MDES = 'MDES';
     public const TOKEN_TYPE_VTS = 'VTS';
 
-    #[SerializedName('Number')]
-    private string $number;
-
-    #[SerializedName('ExpMonth')]
-    private int $expMonth;
-
-    #[SerializedName('ExpYear')]
-    private int $expYear;
-
-    #[SerializedName('AuthValue')]
-    private string $authValue;
-
     #[SerializedName('Eci')]
     private ?string $eci = null;
 
-    #[SerializedName('TokenType')]
-    private string $tokenType;
-
-    public function __construct(string $number, int $expMonth, int $expYear, string $authValue, string $tokenType)
-    {
-        $this->number = $number;
-        $this->expMonth = $expMonth;
-        $this->expYear = $expYear;
-        $this->authValue = $authValue;
-        $this->tokenType = $tokenType;
+    public function __construct(
+        #[SerializedName('Number')]
+        private readonly string $number,
+        #[SerializedName('ExpMonth')]
+        private readonly int $expMonth,
+        #[SerializedName('ExpYear')]
+        private readonly int $expYear,
+        #[SerializedName('AuthValue')]
+        private readonly string $authValue,
+        #[SerializedName('TokenType')]
+        private readonly string $tokenType,
+    ) {
     }
 
     public function getNumber(): string

--- a/lib/SaferpayJson/Request/Container/Transaction/Ideal.php
+++ b/lib/SaferpayJson/Request/Container/Transaction/Ideal.php
@@ -6,14 +6,12 @@ namespace Ticketpark\SaferpayJson\Request\Container\Transaction;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class Ideal
+final readonly class Ideal
 {
-    #[SerializedName('AccountHolderName')]
-    private string $accountHolderName;
-
-    public function __construct(string $accountHolderName)
-    {
-        $this->accountHolderName = $accountHolderName;
+    public function __construct(
+        #[SerializedName('AccountHolderName')]
+        private string $accountHolderName,
+    ) {
     }
 
     public function getAccountHolderName(): string

--- a/lib/SaferpayJson/Request/Container/UpdateAlias.php
+++ b/lib/SaferpayJson/Request/Container/UpdateAlias.php
@@ -8,15 +8,13 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class UpdateAlias
 {
-    #[SerializedName('Id')]
-    private string $id;
-
     #[SerializedName('Lifetime')]
     private ?int $lifetime = null;
 
-    public function __construct(string $id)
-    {
-        $this->id = $id;
+    public function __construct(
+        #[SerializedName('Id')]
+        private readonly string $id,
+    ) {
     }
 
     public function getId(): ?string

--- a/lib/SaferpayJson/Request/Container/UpdatePaymentMeans.php
+++ b/lib/SaferpayJson/Request/Container/UpdatePaymentMeans.php
@@ -6,14 +6,12 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 
-final class UpdatePaymentMeans
+final readonly class UpdatePaymentMeans
 {
-    #[SerializedName('Card')]
-    private Card $card;
-
-    public function __construct(Card $card)
-    {
-        $this->card = $card;
+    public function __construct(
+        #[SerializedName('Card')]
+        private Card $card,
+    ) {
     }
 
     public function getCard(): ?Card

--- a/lib/SaferpayJson/Request/PaymentPage/AssertRequest.php
+++ b/lib/SaferpayJson/Request/PaymentPage/AssertRequest.php
@@ -16,28 +16,17 @@ final class AssertRequest extends Request
     public const API_PATH = '/Payment/v1/PaymentPage/Assert';
     public const RESPONSE_CLASS = AssertResponse::class;
 
-    #[SerializedName('Token')]
-    private string $token;
-
     public function __construct(
         RequestConfig $requestConfig,
-        string $token,
+        #[SerializedName('Token')]
+        private readonly string $token,
     ) {
-        $this->token = $token;
-
         parent::__construct($requestConfig);
     }
 
     public function getToken(): string
     {
         return $this->token;
-    }
-
-    public function setToken(string $token): self
-    {
-        $this->token = $token;
-
-        return $this;
     }
 
     public function execute(): AssertResponse

--- a/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
@@ -61,15 +61,6 @@ final class InitializeRequest extends Request
     public const CONDITION_WITH_SUCCESSFUL_THREE_DS_CHALLENGE = 'WITH_SUCCESSFUL_THREE_DS_CHALLENGE';
     public const CONDITION_NONE = 'NONE';
 
-    #[SerializedName('TerminalId')]
-    private string $terminalId;
-
-    #[SerializedName('Payment')]
-    private Payment $payment;
-
-    #[SerializedName('ReturnUrl')]
-    private ReturnUrl $returnUrl;
-
     #[SerializedName('ConfigSet')]
     private ?string $configSet = null;
 
@@ -116,14 +107,13 @@ final class InitializeRequest extends Request
 
     public function __construct(
         RequestConfig $requestConfig,
-        string $terminalId,
-        Payment $payment,
-        ReturnUrl $returnUrl,
+        #[SerializedName('TerminalId')]
+        private readonly string $terminalId,
+        #[SerializedName('Payment')]
+        private readonly Payment $payment,
+        #[SerializedName('ReturnUrl')]
+        private readonly ReturnUrl $returnUrl,
     ) {
-        $this->terminalId = $terminalId;
-        $this->payment = $payment;
-        $this->returnUrl = $returnUrl;
-
         parent::__construct($requestConfig);
     }
 
@@ -132,35 +122,14 @@ final class InitializeRequest extends Request
         return $this->terminalId;
     }
 
-    public function setTerminalId(string $terminalId): self
-    {
-        $this->terminalId = $terminalId;
-
-        return $this;
-    }
-
     public function getPayment(): Payment
     {
         return $this->payment;
     }
 
-    public function setPayment(Payment $payment): self
-    {
-        $this->payment = $payment;
-
-        return $this;
-    }
-
     public function getReturnUrl(): ReturnUrl
     {
         return $this->returnUrl;
-    }
-
-    public function setReturnUrl(ReturnUrl $returnUrl): self
-    {
-        $this->returnUrl = $returnUrl;
-
-        return $this;
     }
 
     public function getConfigSet(): ?string

--- a/lib/SaferpayJson/Request/Request.php
+++ b/lib/SaferpayJson/Request/Request.php
@@ -20,9 +20,6 @@ abstract class Request
 {
     private const ERROR_RESPONSE_CLASS = ErrorResponse::class;
 
-    #[Exclude]
-    private RequestConfig $requestConfig;
-
     abstract public function execute(): Response;
 
     abstract public function getApiPath(): string;
@@ -32,9 +29,10 @@ abstract class Request
      */
     abstract public function getResponseClass(): string;
 
-    public function __construct(RequestConfig $requestConfig)
-    {
-        $this->requestConfig = $requestConfig;
+    public function __construct(
+        #[Exclude]
+        private readonly RequestConfig $requestConfig,
+    ) {
     }
 
     #[SerializedName('RequestHeader')]

--- a/lib/SaferpayJson/Request/SecureCardData/AliasAssertInsertRequest.php
+++ b/lib/SaferpayJson/Request/SecureCardData/AliasAssertInsertRequest.php
@@ -16,26 +16,17 @@ final class AliasAssertInsertRequest extends Request
     public const API_PATH = '/Payment/v1/Alias/AssertInsert';
     public const RESPONSE_CLASS = AliasAssertInsertResponse::class;
 
-    #[SerializedName('Token')]
-    private string $token;
-
-    public function __construct(RequestConfig $requestConfig, string $token)
-    {
-        $this->token = $token;
-
+    public function __construct(
+        RequestConfig $requestConfig,
+        #[SerializedName('Token')]
+        private readonly string $token,
+    ) {
         parent::__construct($requestConfig);
     }
 
     public function getToken(): string
     {
         return $this->token;
-    }
-
-    public function setToken(string $token): self
-    {
-        $this->token = $token;
-
-        return $this;
     }
 
     public function execute(): AliasAssertInsertResponse

--- a/lib/SaferpayJson/Request/SecureCardData/AliasDeleteRequest.php
+++ b/lib/SaferpayJson/Request/SecureCardData/AliasDeleteRequest.php
@@ -16,26 +16,17 @@ final class AliasDeleteRequest extends Request
     public const API_PATH = '/Payment/v1/Alias/Delete';
     public const RESPONSE_CLASS = AliasDeleteResponse::class;
 
-    #[SerializedName('AliasId')]
-    private string $aliasId;
-
-    public function __construct(RequestConfig $requestConfig, string $aliasId)
-    {
-        $this->aliasId = $aliasId;
-
+    public function __construct(
+        RequestConfig $requestConfig,
+        #[SerializedName('AliasId')]
+        private readonly string $aliasId,
+    ) {
         parent::__construct($requestConfig);
     }
 
     public function getAliasId(): string
     {
         return $this->aliasId;
-    }
-
-    public function setAliasId(string $aliasId): self
-    {
-        $this->aliasId = $aliasId;
-
-        return $this;
     }
 
     public function execute(): AliasDeleteResponse

--- a/lib/SaferpayJson/Request/SecureCardData/AliasInsertDirectRequest.php
+++ b/lib/SaferpayJson/Request/SecureCardData/AliasInsertDirectRequest.php
@@ -21,12 +21,6 @@ final class AliasInsertDirectRequest extends Request
     public const API_PATH = '/Payment/v1/Alias/InsertDirect';
     public const RESPONSE_CLASS = AliasInsertDirectResponse::class;
 
-    #[SerializedName('RegisterAlias')]
-    private RegisterAlias $registerAlias;
-
-    #[SerializedName('PaymentMeans')]
-    private PaymentMeans $paymentMeans;
-
     #[SerializedName('Check')]
     private ?Check $check = null;
 
@@ -36,11 +30,13 @@ final class AliasInsertDirectRequest extends Request
     #[SerializedName('IssuerReference')]
     private ?IssuerReference $issuerReference = null;
 
-    public function __construct(RequestConfig $requestConfig, RegisterAlias $registerAlias, PaymentMeans $paymentMeans)
-    {
-        $this->registerAlias = $registerAlias;
-        $this->paymentMeans = $paymentMeans;
-
+    public function __construct(
+        RequestConfig $requestConfig,
+        #[SerializedName('RegisterAlias')]
+        private readonly RegisterAlias $registerAlias,
+        #[SerializedName('PaymentMeans')]
+        private readonly PaymentMeans $paymentMeans,
+    ) {
         parent::__construct($requestConfig);
     }
 
@@ -49,23 +45,9 @@ final class AliasInsertDirectRequest extends Request
         return $this->registerAlias;
     }
 
-    public function setRegisterAlias(RegisterAlias $registerAlias): self
-    {
-        $this->registerAlias = $registerAlias;
-
-        return $this;
-    }
-
     public function getPaymentMeans(): PaymentMeans
     {
         return $this->paymentMeans;
-    }
-
-    public function setPaymentMeans(PaymentMeans $paymentMeans): self
-    {
-        $this->paymentMeans = $paymentMeans;
-
-        return $this;
     }
 
     public function getCheck(): ?Check

--- a/lib/SaferpayJson/Request/SecureCardData/AliasInsertRequest.php
+++ b/lib/SaferpayJson/Request/SecureCardData/AliasInsertRequest.php
@@ -40,15 +40,6 @@ final class AliasInsertRequest extends Request
     public const TYPE_POSTFINANCE = 'POSTFINANCE';
     public const TYPE_TWINT = 'TWINT';
 
-    #[SerializedName('RegisterAlias')]
-    private RegisterAlias $registerAlias;
-
-    #[SerializedName('Type')]
-    private string $type;
-
-    #[SerializedName('ReturnUrl')]
-    private ReturnUrl $returnUrl;
-
     #[SerializedName('Styling')]
     private ?Styling $styling = null;
 
@@ -73,14 +64,13 @@ final class AliasInsertRequest extends Request
 
     public function __construct(
         RequestConfig $requestConfig,
-        RegisterAlias $registerAlias,
-        string $type,
-        ReturnUrl $returnUrl,
+        #[SerializedName('RegisterAlias')]
+        private readonly RegisterAlias $registerAlias,
+        #[SerializedName('Type')]
+        private readonly string $type,
+        #[SerializedName('ReturnUrl')]
+        private readonly ReturnUrl $returnUrl,
     ) {
-        $this->registerAlias = $registerAlias;
-        $this->type = $type;
-        $this->returnUrl = $returnUrl;
-
         parent::__construct($requestConfig);
     }
 
@@ -89,35 +79,14 @@ final class AliasInsertRequest extends Request
         return $this->registerAlias;
     }
 
-    public function setRegisterAlias(RegisterAlias $registerAlias): self
-    {
-        $this->registerAlias = $registerAlias;
-
-        return $this;
-    }
-
     public function getType(): string
     {
         return $this->type;
     }
 
-    public function setType(string $type): self
-    {
-        $this->type = $type;
-
-        return $this;
-    }
-
     public function getReturnUrl(): ReturnUrl
     {
         return $this->returnUrl;
-    }
-
-    public function setReturnUrl(ReturnUrl $returnUrl): self
-    {
-        $this->returnUrl = $returnUrl;
-
-        return $this;
     }
 
     public function getStyling(): ?Styling

--- a/lib/SaferpayJson/Request/SecureCardData/AliasUpdateRequest.php
+++ b/lib/SaferpayJson/Request/SecureCardData/AliasUpdateRequest.php
@@ -18,20 +18,13 @@ final class AliasUpdateRequest extends Request
     public const API_PATH = '/Payment/v1/Alias/Update';
     public const RESPONSE_CLASS = AliasUpdateResponse::class;
 
-    #[SerializedName('UpdateAlias')]
-    private UpdateAlias $updateAlias;
-
-    #[SerializedName('UpdatePaymentMeans')]
-    private UpdatePaymentMeans $updatePaymentMeans;
-
     public function __construct(
         RequestConfig $requestConfig,
-        UpdateAlias $updateAlias,
-        UpdatePaymentMeans $updatePaymentMeans,
+        #[SerializedName('UpdateAlias')]
+        private readonly UpdateAlias $updateAlias,
+        #[SerializedName('UpdatePaymentMeans')]
+        private readonly UpdatePaymentMeans $updatePaymentMeans,
     ) {
-        $this->updateAlias = $updateAlias;
-        $this->updatePaymentMeans = $updatePaymentMeans;
-
         parent::__construct($requestConfig);
     }
 
@@ -40,23 +33,9 @@ final class AliasUpdateRequest extends Request
         return $this->updateAlias;
     }
 
-    public function setUpdateAlias(UpdateAlias $updateAlias): self
-    {
-        $this->updateAlias = $updateAlias;
-
-        return $this;
-    }
-
     public function getUpdatePaymentMeans(): ?UpdatePaymentMeans
     {
         return $this->updatePaymentMeans;
-    }
-
-    public function setUpdatePaymentMeans(UpdatePaymentMeans $updatePaymentMeans): self
-    {
-        $this->updatePaymentMeans = $updatePaymentMeans;
-
-        return $this;
     }
 
     public function execute(): AliasUpdateResponse

--- a/lib/SaferpayJson/Request/Transaction/AuthorizeDirectRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/AuthorizeDirectRequest.php
@@ -27,15 +27,6 @@ final class AuthorizeDirectRequest extends Request
     public const INITIATOR_MERCHANT = 'MERCHANT';
     public const INITIATOR_PAYER = 'PAYER';
 
-    #[SerializedName('TerminalId')]
-    private string $terminalId;
-
-    #[SerializedName('Payment')]
-    private Payment $payment;
-
-    #[SerializedName('PaymentMeans')]
-    private PaymentMeans $paymentMeans;
-
     #[SerializedName('Authentication')]
     private ?Authentication $authentication = null;
 
@@ -59,14 +50,13 @@ final class AuthorizeDirectRequest extends Request
 
     public function __construct(
         RequestConfig $requestConfig,
-        string $terminalId,
-        Payment $payment,
-        PaymentMeans $paymentMeans,
+        #[SerializedName('TerminalId')]
+        private readonly string $terminalId,
+        #[SerializedName('Payment')]
+        private readonly Payment $payment,
+        #[SerializedName('PaymentMeans')]
+        private readonly PaymentMeans $paymentMeans,
     ) {
-        $this->terminalId = $terminalId;
-        $this->payment = $payment;
-        $this->paymentMeans = $paymentMeans;
-
         parent::__construct($requestConfig);
     }
 
@@ -75,35 +65,14 @@ final class AuthorizeDirectRequest extends Request
         return $this->terminalId;
     }
 
-    public function setTerminalId(string $terminalId): self
-    {
-        $this->terminalId = $terminalId;
-
-        return $this;
-    }
-
     public function getPayment(): Payment
     {
         return $this->payment;
     }
 
-    public function setPayment(Payment $payment): self
-    {
-        $this->payment = $payment;
-
-        return $this;
-    }
-
     public function getPaymentMeans(): PaymentMeans
     {
         return $this->paymentMeans;
-    }
-
-    public function setPaymentMeans(PaymentMeans $paymentMeans): self
-    {
-        $this->paymentMeans = $paymentMeans;
-
-        return $this;
     }
 
     public function getAuthentication(): ?Authentication

--- a/lib/SaferpayJson/Request/Transaction/AuthorizeReferencedRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/AuthorizeReferencedRequest.php
@@ -20,15 +20,6 @@ final class AuthorizeReferencedRequest extends Request
     public const API_PATH = '/Payment/v1/Transaction/AuthorizeReferenced';
     public const RESPONSE_CLASS = AuthorizeReferencedResponse::class;
 
-    #[SerializedName('TerminalId')]
-    private string $terminalId;
-
-    #[SerializedName('Payment')]
-    private Payment $payment;
-
-    #[SerializedName('TransactionReference')]
-    private TransactionReference $transactionReference;
-
     #[SerializedName('Authentication')]
     private ?Authentication $authentication = null;
 
@@ -40,14 +31,13 @@ final class AuthorizeReferencedRequest extends Request
 
     public function __construct(
         RequestConfig $requestConfig,
-        string $terminalId,
-        Payment $payment,
-        TransactionReference $transactionReference,
+        #[SerializedName('TerminalId')]
+        private readonly string $terminalId,
+        #[SerializedName('Payment')]
+        private readonly Payment $payment,
+        #[SerializedName('TransactionReference')]
+        private readonly TransactionReference $transactionReference,
     ) {
-        $this->terminalId = $terminalId;
-        $this->payment = $payment;
-        $this->transactionReference = $transactionReference;
-
         parent::__construct($requestConfig);
     }
 
@@ -56,35 +46,14 @@ final class AuthorizeReferencedRequest extends Request
         return $this->terminalId;
     }
 
-    public function setTerminalId(string $terminalId): self
-    {
-        $this->terminalId = $terminalId;
-
-        return $this;
-    }
-
     public function getPayment(): Payment
     {
         return $this->payment;
     }
 
-    public function setPayment(Payment $payment): self
-    {
-        $this->payment = $payment;
-
-        return $this;
-    }
-
     public function getTransactionReference(): TransactionReference
     {
         return $this->transactionReference;
-    }
-
-    public function setTransactionReference(TransactionReference $transactionReference): self
-    {
-        $this->transactionReference = $transactionReference;
-
-        return $this;
     }
 
     public function getAuthentication(): ?Authentication

--- a/lib/SaferpayJson/Request/Transaction/AuthorizeRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/AuthorizeRequest.php
@@ -21,9 +21,6 @@ final class AuthorizeRequest extends Request
     public const CONDITION_WITH_SUCCESSFUL_THREE_DS_CHALLENGE = 'WITH_SUCCESSFUL_THREE_DS_CHALLENGE';
     public const CONDITION_NONE = 'NONE';
 
-    #[SerializedName('Token')]
-    private string $token;
-
     #[SerializedName('Condition')]
     private ?string $condition = null;
 
@@ -35,10 +32,9 @@ final class AuthorizeRequest extends Request
 
     public function __construct(
         RequestConfig $requestConfig,
-        string $token,
+        #[SerializedName('Token')]
+        private readonly string $token,
     ) {
-        $this->token = $token;
-
         parent::__construct($requestConfig);
     }
 

--- a/lib/SaferpayJson/Request/Transaction/CancelRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/CancelRequest.php
@@ -17,28 +17,17 @@ final class CancelRequest extends Request
     public const API_PATH = '/Payment/v1/Transaction/Cancel';
     public const RESPONSE_CLASS = CancelResponse::class;
 
-    #[SerializedName('TransactionReference')]
-    private TransactionReference $transactionReference;
-
     public function __construct(
         RequestConfig $requestConfig,
-        TransactionReference $transactionReference,
+        #[SerializedName('TransactionReference')]
+        private readonly TransactionReference $transactionReference,
     ) {
-        $this->transactionReference = $transactionReference;
-
         parent::__construct($requestConfig);
     }
 
     public function getTransactionReference(): TransactionReference
     {
         return $this->transactionReference;
-    }
-
-    public function setTransactionReference(TransactionReference $transactionReference): self
-    {
-        $this->transactionReference = $transactionReference;
-
-        return $this;
     }
 
     public function execute(): CancelResponse

--- a/lib/SaferpayJson/Request/Transaction/CaptureRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/CaptureRequest.php
@@ -22,9 +22,6 @@ final class CaptureRequest extends Request
     public const API_PATH = '/Payment/v1/Transaction/Capture';
     public const RESPONSE_CLASS = CaptureResponse::class;
 
-    #[SerializedName('TransactionReference')]
-    private TransactionReference $transactionReference;
-
     #[SerializedName('Amount')]
     private ?Amount $amount = null;
 
@@ -42,23 +39,15 @@ final class CaptureRequest extends Request
 
     public function __construct(
         RequestConfig $requestConfig,
-        TransactionReference $transactionReference,
+        #[SerializedName('TransactionReference')]
+        private readonly TransactionReference $transactionReference,
     ) {
-        $this->transactionReference = $transactionReference;
-
         parent::__construct($requestConfig);
     }
 
     public function getTransactionReference(): TransactionReference
     {
         return $this->transactionReference;
-    }
-
-    public function setTransactionReference(TransactionReference $transactionReference): self
-    {
-        $this->transactionReference = $transactionReference;
-
-        return $this;
     }
 
     public function getAmount(): ?Amount

--- a/lib/SaferpayJson/Request/Transaction/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/InitializeRequest.php
@@ -44,12 +44,6 @@ final class InitializeRequest extends Request
     #[SerializedName('ConfigSet')]
     private ?string $configSet = null;
 
-    #[SerializedName('TerminalId')]
-    private string $terminalId;
-
-    #[SerializedName('Payment')]
-    private Payment $payment;
-
     #[SerializedName('PaymentMeans')]
     private ?PaymentMeans $paymentMeans = null;
 
@@ -58,9 +52,6 @@ final class InitializeRequest extends Request
 
     #[SerializedName('Payer')]
     private ?Payer $payer = null;
-
-    #[SerializedName('ReturnUrl')]
-    private ReturnUrl $returnUrl;
 
     #[SerializedName('Styling')]
     private ?Styling $styling = null;
@@ -86,14 +77,13 @@ final class InitializeRequest extends Request
 
     public function __construct(
         RequestConfig $requestConfig,
-        string $terminalId,
-        Payment $payment,
-        ReturnUrl $returnUrl,
+        #[SerializedName('TerminalId')]
+        private readonly string $terminalId,
+        #[SerializedName('Payment')]
+        private readonly Payment $payment,
+        #[SerializedName('ReturnUrl')]
+        private readonly ReturnUrl $returnUrl,
     ) {
-        $this->terminalId = $terminalId;
-        $this->payment = $payment;
-        $this->returnUrl = $returnUrl;
-
         parent::__construct($requestConfig);
     }
 

--- a/lib/SaferpayJson/Request/Transaction/InquireRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/InquireRequest.php
@@ -17,28 +17,17 @@ final class InquireRequest extends Request
     public const API_PATH = '/Payment/v1/Transaction/Inquire';
     public const RESPONSE_CLASS = InquireResponse::class;
 
-    #[SerializedName('TransactionReference')]
-    private TransactionReference $transactionReference;
-
     public function __construct(
         RequestConfig $requestConfig,
-        TransactionReference $transactionReference,
+        #[SerializedName('TransactionReference')]
+        private readonly TransactionReference $transactionReference,
     ) {
-        $this->transactionReference = $transactionReference;
-
         parent::__construct($requestConfig);
     }
 
     public function getTransactionReference(): TransactionReference
     {
         return $this->transactionReference;
-    }
-
-    public function setTransactionReference(TransactionReference $transactionReference): self
-    {
-        $this->transactionReference = $transactionReference;
-
-        return $this;
     }
 
     public function execute(): InquireResponse

--- a/lib/SaferpayJson/Request/Transaction/RefundRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/RefundRequest.php
@@ -20,12 +20,6 @@ final class RefundRequest extends Request
     public const API_PATH = '/Payment/v1/Transaction/Refund';
     public const RESPONSE_CLASS = RefundResponse::class;
 
-    #[SerializedName('Refund')]
-    private Refund $refund;
-
-    #[SerializedName('CaptureReference')]
-    private CaptureReference $captureReference;
-
     #[SerializedName('PendingNotification')]
     private ?PendingNotification $pendingNotification = null;
 
@@ -34,12 +28,11 @@ final class RefundRequest extends Request
 
     public function __construct(
         RequestConfig $requestConfig,
-        Refund $refund,
-        CaptureReference $captureReference,
+        #[SerializedName('Refund')]
+        private readonly Refund $refund,
+        #[SerializedName('CaptureReference')]
+        private readonly CaptureReference $captureReference,
     ) {
-        $this->refund = $refund;
-        $this->captureReference = $captureReference;
-
         parent::__construct($requestConfig);
     }
 
@@ -48,23 +41,9 @@ final class RefundRequest extends Request
         return $this->refund;
     }
 
-    public function setRefund(Refund $refund): self
-    {
-        $this->refund = $refund;
-
-        return $this;
-    }
-
     public function getCaptureReference(): ?CaptureReference
     {
         return $this->captureReference;
-    }
-
-    public function setCaptureReference(CaptureReference $captureReference): self
-    {
-        $this->captureReference = $captureReference;
-
-        return $this;
     }
 
     public function getPendingNotification(): ?PendingNotification


### PR DESCRIPTION
Closes #121

- Adopt constructor property promotion and `readonly` for request containers with mandatory constructor fields
- Use `readonly class` for simple DTOs without optional properties (e.g. `Amount`, `ReturnUrl`, `ApplePay`)
- Apply constructor promotion to all `*Request` classes and the base `Request` class
- Remove setters on mandatory constructor fields (`Payment`, `Refund`, and affected request classes)
- Align class member order with Symfony conventions: constants, properties, constructor, methods

Made with [Cursor](https://cursor.com)