### PR TITLE
feat: Replace shared vocabulary constants with backed enums

### DIFF
--- a/example/SecureCardData/example-alias-insert-direct.php
+++ b/example/SecureCardData/example-alias-insert-direct.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use Ticketpark\SaferpayJson\Enum\AliasIdGenerator;
 use Ticketpark\SaferpayJson\Request\Exception\SaferpayErrorException;
 use Ticketpark\SaferpayJson\Request\Container;
 use Ticketpark\SaferpayJson\Request\SecureCardData\AliasInsertDirectRequest;
@@ -21,7 +22,7 @@ $requestConfig = new RequestConfig(
 );
 
 $registerAlias = new Container\RegisterAlias(
-    Container\RegisterAlias::ID_GENERATOR_RANDOM
+    AliasIdGenerator::Random
 );
 
 $card = (new Container\Card())

--- a/example/SecureCardData/example-alias-insert.php
+++ b/example/SecureCardData/example-alias-insert.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Ticketpark\SaferpayJson\Enum\AliasIdGenerator;
+use Ticketpark\SaferpayJson\Enum\AliasInsertType;
 use Ticketpark\SaferpayJson\Request\Exception\SaferpayErrorException;
 use Ticketpark\SaferpayJson\Request\Container;
 use Ticketpark\SaferpayJson\Request\SecureCardData\AliasInsertRequest;
@@ -21,7 +23,7 @@ $requestConfig = new RequestConfig(
 );
 
 $registerAlias = new Container\RegisterAlias(
-    Container\RegisterAlias::ID_GENERATOR_RANDOM
+    AliasIdGenerator::Random
 );
 
 $returnUrl = new Container\ReturnUrl(
@@ -35,7 +37,7 @@ $returnUrl = new Container\ReturnUrl(
 $insertRequest = new AliasInsertRequest(
     $requestConfig,
     $registerAlias,
-    AliasInsertRequest::TYPE_CARD,
+    AliasInsertType::Card,
     $returnUrl
 );
 

--- a/lib/SaferpayJson/Enum/AddressFormMandatoryField.php
+++ b/lib/SaferpayJson/Enum/AddressFormMandatoryField.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum AddressFormMandatoryField: string
+{
+    case City = 'CITY';
+    case Company = 'COMPANY';
+    case Country = 'COUNTRY';
+    case Email = 'EMAIL';
+    case Firstname = 'FIRSTNAME';
+    case Lastname = 'LASTNAME';
+    case Phone = 'PHONE';
+    case Salutation = 'SALUTATION';
+    case State = 'STATE';
+    case Street = 'STREET';
+    case Zip = 'ZIP';
+}

--- a/lib/SaferpayJson/Enum/AddressSource.php
+++ b/lib/SaferpayJson/Enum/AddressSource.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum AddressSource: string
+{
+    case None = 'NONE';
+    case Saferpay = 'SAFERPAY';
+    case PreferPaymentMethod = 'PREFER_PAYMENTMETHOD';
+}

--- a/lib/SaferpayJson/Enum/AliasIdGenerator.php
+++ b/lib/SaferpayJson/Enum/AliasIdGenerator.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum AliasIdGenerator: string
+{
+    case Manual = 'MANUAL';
+    case Random = 'RANDOM';
+    case RandomUnique = 'RANDOM_UNIQUE';
+}

--- a/lib/SaferpayJson/Enum/AliasInsertType.php
+++ b/lib/SaferpayJson/Enum/AliasInsertType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum AliasInsertType: string
+{
+    case Card = 'CARD';
+    case BankAccount = 'BANK_ACCOUNT';
+    case Postfinance = 'POSTFINANCE';
+    case Twint = 'TWINT';
+}

--- a/lib/SaferpayJson/Enum/CardScheme.php
+++ b/lib/SaferpayJson/Enum/CardScheme.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum CardScheme: string
+{
+    case Mastercard = 'MASTERCARD';
+    case Visa = 'VISA';
+    case Jcb = 'JCB';
+    case Diners = 'DINERS';
+    case Amex = 'AMEX';
+}

--- a/lib/SaferpayJson/Enum/CheckType.php
+++ b/lib/SaferpayJson/Enum/CheckType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum CheckType: string
+{
+    case Online = 'ONLINE';
+    case OnlineStrong = 'ONLINE_STRONG';
+}

--- a/lib/SaferpayJson/Enum/DeliveryType.php
+++ b/lib/SaferpayJson/Enum/DeliveryType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum DeliveryType: string
+{
+    case Email = 'EMAIL';
+    case Shop = 'SHOP';
+    case HomeDelivery = 'HOMEDELIVERY';
+    case Pickup = 'PICKUP';
+    case Hq = 'HQ';
+}

--- a/lib/SaferpayJson/Enum/Gender.php
+++ b/lib/SaferpayJson/Enum/Gender.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum Gender: string
+{
+    case Male = 'MALE';
+    case Female = 'FEMALE';
+    case Diverse = 'DIVERSE';
+    case Company = 'COMPANY';
+}

--- a/lib/SaferpayJson/Enum/Initiator.php
+++ b/lib/SaferpayJson/Enum/Initiator.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum Initiator: string
+{
+    case Merchant = 'MERCHANT';
+    case Payer = 'PAYER';
+}

--- a/lib/SaferpayJson/Enum/OrderItemType.php
+++ b/lib/SaferpayJson/Enum/OrderItemType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum OrderItemType: string
+{
+    case Digital = 'DIGITAL';
+    case Physical = 'PHYSICAL';
+    case Service = 'SERVICE';
+    case Giftcard = 'GIFTCARD';
+    case Discount = 'DISCOUNT';
+    case ShippingFee = 'SHIPPINGFEE';
+    case SalesTax = 'SALESTAX';
+    case Surcharge = 'SURCHARGE';
+}

--- a/lib/SaferpayJson/Enum/PaymentMethod.php
+++ b/lib/SaferpayJson/Enum/PaymentMethod.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum PaymentMethod: string
+{
+    case AccountToAccount = 'ACCOUNTTOACCOUNT';
+    case Alipay = 'ALIPAY';
+    case Amex = 'AMEX';
+    case Bancontact = 'BANCONTACT';
+    case Card = 'CARD';
+    case Diners = 'DINERS';
+    case DirectDebit = 'DIRECTDEBIT';
+    case Eprzelewy = 'EPRZELEWY';
+    case Eps = 'EPS';
+    case Ideal = 'IDEAL';
+    case Invoice = 'INVOICE';
+    case Jcb = 'JCB';
+    case Klarna = 'KLARNA';
+    case Maestro = 'MAESTRO';
+    case Mastercard = 'MASTERCARD';
+    case Payconiq = 'PAYCONIQ';
+    case Paypal = 'PAYPAL';
+    case Postcard = 'POSTCARD';
+    case Postfinance = 'POSTFINANCE';
+    case PostfinancePay = 'POSTFINANCEPAY';
+    case Reka = 'REKA';
+    case SaferpayTest = 'SAFERPAYTEST';
+    case Twint = 'TWINT';
+    case Unionpay = 'UNIONPAY';
+    case Visa = 'VISA';
+    case Vpay = 'VPAY';
+    case Wero = 'WERO';
+    case Wechatpay = 'WECHATPAY';
+}

--- a/lib/SaferpayJson/Enum/SchemeTokenType.php
+++ b/lib/SaferpayJson/Enum/SchemeTokenType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum SchemeTokenType: string
+{
+    case ApplePay = 'APPLEPAY';
+    case GooglePay = 'GOOGLEPAY';
+    case SamsungPay = 'SAMSUNGPAY';
+    case ClickToPay = 'CLICKTOPAY';
+    case Other = 'OTHER';
+    case Mdes = 'MDES';
+    case Vts = 'VTS';
+}

--- a/lib/SaferpayJson/Enum/StylingTheme.php
+++ b/lib/SaferpayJson/Enum/StylingTheme.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum StylingTheme: string
+{
+    case Default = 'DEFAULT';
+    case Six = 'SIX';
+    case None = 'NONE';
+}

--- a/lib/SaferpayJson/Enum/ThreeDsAuthenticationMode.php
+++ b/lib/SaferpayJson/Enum/ThreeDsAuthenticationMode.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum ThreeDsAuthenticationMode: string
+{
+    case Challenge = 'CHALLENGE';
+    case Frictionless = 'FRICTIONLESS';
+}

--- a/lib/SaferpayJson/Enum/ThreeDsCondition.php
+++ b/lib/SaferpayJson/Enum/ThreeDsCondition.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum ThreeDsCondition: string
+{
+    case ThreeDsAuthenticationSuccessfulOrAttempted = 'THREE_DS_AUTHENTICATION_SUCCESSFUL_OR_ATTEMPTED';
+    case WithSuccessfulThreeDsChallenge = 'WITH_SUCCESSFUL_THREE_DS_CHALLENGE';
+    case None = 'NONE';
+}

--- a/lib/SaferpayJson/Enum/ThreeDsTransStatus.php
+++ b/lib/SaferpayJson/Enum/ThreeDsTransStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum ThreeDsTransStatus: string
+{
+    case Y = 'Y';
+    case A = 'A';
+    case U = 'U';
+    case I = 'I';
+}

--- a/lib/SaferpayJson/Enum/Wallet.php
+++ b/lib/SaferpayJson/Enum/Wallet.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ticketpark\SaferpayJson\Enum;
+
+enum Wallet: string
+{
+    case ApplePay = 'APPLEPAY';
+    case GooglePay = 'GOOGLEPAY';
+    case ClickToPay = 'CLICKTOPAY';
+    case Masterpass = 'MASTERPASS';
+}

--- a/lib/SaferpayJson/Request/Container/Address.php
+++ b/lib/SaferpayJson/Request/Container/Address.php
@@ -5,14 +5,10 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\Gender;
 
 final class Address
 {
-    public const GENDER_MALE = 'MALE';
-    public const GENDER_FEMALE = 'FEMALE';
-    public const GENDER_DIVERSE = 'DIVERSE';
-    public const GENDER_COMPANY = 'COMPANY';
-
     #[SerializedName('FirstName')]
     private ?string $firstName = null;
 
@@ -23,7 +19,7 @@ final class Address
     private ?string $company = null;
 
     #[SerializedName('Gender')]
-    private ?string $gender = null;
+    private ?Gender $gender = null;
 
     #[SerializedName('Street')]
     private ?string $street = null;
@@ -91,12 +87,12 @@ final class Address
         return $this;
     }
 
-    public function getGender(): ?string
+    public function getGender(): ?Gender
     {
         return $this->gender;
     }
 
-    public function setGender(?string $gender): self
+    public function setGender(?Gender $gender): self
     {
         $this->gender = $gender;
 

--- a/lib/SaferpayJson/Request/Container/AddressForm.php
+++ b/lib/SaferpayJson/Request/Container/AddressForm.php
@@ -5,47 +5,33 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\AddressFormMandatoryField;
+use Ticketpark\SaferpayJson\Enum\AddressSource;
 
 final class AddressForm
 {
-    public const MANDATORY_FIELD_CITY = 'CITY';
-    public const MANDATORY_FIELD_COMPANY = 'COMPANY';
-    public const MANDATORY_FIELD_COUNTRY = 'COUNTRY';
-    public const MANDATORY_FIELD_EMAIL = 'EMAIL';
-    public const MANDATORY_FIELD_FIRSTNAME = 'FIRSTNAME';
-    public const MANDATORY_FIELD_LASTNAME = 'LASTNAME';
-    public const MANDATORY_FIELD_PHONE = 'PHONE';
-    public const MANDATORY_FIELD_SALUTATION = 'SALUTATION';
-    public const MANDATORY_FIELD_STATE = 'STATE';
-    public const MANDATORY_FIELD_STREET = 'STREET';
-    public const MANDATORY_FIELD_ZIP = 'ZIP';
-
-    public const ADDRESS_SOURCE_NONE = 'NONE';
-    public const ADDRESS_SOURCE_SAFERPAY = 'SAFERPAY';
-    public const ADDRESS_SOURCE_PREFER_PAYMENTMETHOD = 'PREFER_PAYMENTMETHOD';
-
-    /** @var list<string>|null */
+    /** @var list<AddressFormMandatoryField>|null */
     #[SerializedName('MandatoryFields')]
     private ?array $mandatoryFields = [];
 
     public function __construct(
         #[SerializedName('AddressSource')]
-        private readonly string $addressSource,
+        private readonly AddressSource $addressSource,
     ) {
     }
 
-    public function getAddressSource(): string
+    public function getAddressSource(): AddressSource
     {
         return $this->addressSource;
     }
 
-    /** @return list<string>|null */
+    /** @return list<AddressFormMandatoryField>|null */
     public function getMandatoryFields(): ?array
     {
         return $this->mandatoryFields;
     }
 
-    /** @param list<string>|null $mandatoryFields */
+    /** @param list<AddressFormMandatoryField>|null $mandatoryFields */
     public function setMandatoryFields(?array $mandatoryFields): self
     {
         $this->mandatoryFields = $mandatoryFields;

--- a/lib/SaferpayJson/Request/Container/Brand.php
+++ b/lib/SaferpayJson/Request/Container/Brand.php
@@ -5,21 +5,22 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\PaymentMethod;
 
 final class Brand
 {
     #[SerializedName('PaymentMethod')]
-    private ?string $paymentMethod = null;
+    private ?PaymentMethod $paymentMethod = null;
 
     #[SerializedName('Name')]
     private ?string $name = null;
 
-    public function getPaymentMethod(): ?string
+    public function getPaymentMethod(): ?PaymentMethod
     {
         return $this->paymentMethod;
     }
 
-    public function setPaymentMethod(?string $paymentMethod): self
+    public function setPaymentMethod(?PaymentMethod $paymentMethod): self
     {
         $this->paymentMethod = $paymentMethod;
 

--- a/lib/SaferpayJson/Request/Container/Check.php
+++ b/lib/SaferpayJson/Request/Container/Check.php
@@ -5,24 +5,22 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\CheckType;
 
 final class Check
 {
-    public const TYPE_ONLINE = 'ONLINE';
-    public const TYPE_ONLINE_STRONG = 'ONLINE_STRONG';
-
     #[SerializedName('Type')]
-    private ?string $type = null;
+    private ?CheckType $type = null;
 
     #[SerializedName('TerminalId')]
     private ?string $terminalId = null;
 
-    public function getType(): ?string
+    public function getType(): ?CheckType
     {
         return $this->type;
     }
 
-    public function setType(?string $type): self
+    public function setType(?CheckType $type): self
     {
         $this->type = $type;
 

--- a/lib/SaferpayJson/Request/Container/ExternalThreeDS.php
+++ b/lib/SaferpayJson/Request/Container/ExternalThreeDS.php
@@ -5,25 +5,14 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\CardScheme;
+use Ticketpark\SaferpayJson\Enum\ThreeDsAuthenticationMode;
+use Ticketpark\SaferpayJson\Enum\ThreeDsTransStatus;
 
 final class ExternalThreeDS
 {
-    public const AUTHENTICATION_MODE_CHALLENGE = 'CHALLENGE';
-    public const AUTHENTICATION_MODE_FRICTIONLESS = 'FRICTIONLESS';
-
-    public const SCHEME_MASTERCARD = 'MASTERCARD';
-    public const SCHEME_VISA = 'VISA';
-    public const SCHEME_JCB = 'JCB';
-    public const SCHEME_DINERS = 'DINERS';
-    public const SCHEME_AMEX = 'AMEX';
-
-    public const TRANS_STATUS_Y = 'Y';
-    public const TRANS_STATUS_A = 'A';
-    public const TRANS_STATUS_U = 'U';
-    public const TRANS_STATUS_I = 'I';
-
     #[SerializedName('AuthenticationMode')]
-    private ?string $authenticationMode = null;
+    private ?ThreeDsAuthenticationMode $authenticationMode = null;
 
     public function __construct(
         #[SerializedName('AcsTransId')]
@@ -37,13 +26,13 @@ final class ExternalThreeDS
         #[SerializedName('Eci')]
         private readonly string $eci,
         #[SerializedName('Scheme')]
-        private readonly string $scheme,
+        private readonly CardScheme $scheme,
         #[SerializedName('ThreeDsFullVersion')]
         private readonly string $threeDsFullVersion,
         #[SerializedName('ThreeDSServerTransId')]
         private readonly string $threeDSServerTransId,
         #[SerializedName('TransStatus')]
-        private readonly string $transStatus,
+        private readonly ThreeDsTransStatus $transStatus,
     ) {
     }
 
@@ -52,12 +41,12 @@ final class ExternalThreeDS
         return $this->acsTransId;
     }
 
-    public function getAuthenticationMode(): ?string
+    public function getAuthenticationMode(): ?ThreeDsAuthenticationMode
     {
         return $this->authenticationMode;
     }
 
-    public function setAuthenticationMode(?string $authenticationMode): self
+    public function setAuthenticationMode(?ThreeDsAuthenticationMode $authenticationMode): self
     {
         $this->authenticationMode = $authenticationMode;
 
@@ -84,7 +73,7 @@ final class ExternalThreeDS
         return $this->eci;
     }
 
-    public function getScheme(): string
+    public function getScheme(): CardScheme
     {
         return $this->scheme;
     }
@@ -99,7 +88,7 @@ final class ExternalThreeDS
         return $this->threeDSServerTransId;
     }
 
-    public function getTransStatus(): string
+    public function getTransStatus(): ThreeDsTransStatus
     {
         return $this->transStatus;
     }

--- a/lib/SaferpayJson/Request/Container/OrderItem.php
+++ b/lib/SaferpayJson/Request/Container/OrderItem.php
@@ -5,20 +5,12 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\OrderItemType;
 
 final class OrderItem
 {
-    public const TYPE_DIGITAL = 'DIGITAL';
-    public const TYPE_PHYSICAL = 'PHYSICAL';
-    public const TYPE_SERVICE = 'SERVICE';
-    public const TYPE_GIFTCARD = 'GIFTCARD';
-    public const TYPE_DISCOUNT = 'DISCOUNT';
-    public const TYPE_SHIPPINGFEE = 'SHIPPINGFEE';
-    public const TYPE_SALESTAX = 'SALESTAX';
-    public const TYPE_SURCHARGE = 'SURCHARGE';
-
     #[SerializedName('Type')]
-    private ?string $type = null;
+    private ?OrderItemType $type = null;
 
     #[SerializedName('Id')]
     private ?string $id = null;
@@ -59,12 +51,12 @@ final class OrderItem
     #[SerializedName('ImageUrl')]
     private ?string $imageUrl = null;
 
-    public function getType(): ?string
+    public function getType(): ?OrderItemType
     {
         return $this->type;
     }
 
-    public function setType(?string $type): self
+    public function setType(?OrderItemType $type): self
     {
         $this->type = $type;
 

--- a/lib/SaferpayJson/Request/Container/PayerProfile.php
+++ b/lib/SaferpayJson/Request/Container/PayerProfile.php
@@ -6,14 +6,10 @@ namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Type;
+use Ticketpark\SaferpayJson\Enum\Gender;
 
 final class PayerProfile
 {
-    public const GENDER_MALE = 'MALE';
-    public const GENDER_FEMALE = 'FEMALE';
-    public const GENDER_DIVERSE = 'DIVERSE';
-    public const GENDER_COMPANY = 'COMPANY';
-
     #[SerializedName('HasAccount')]
     private ?bool $hasAccount = null;
 
@@ -40,7 +36,7 @@ final class PayerProfile
     private ?\DateTime $lastLoginDate = null;
 
     #[SerializedName('Gender')]
-    private ?string $gender = null;
+    private ?Gender $gender = null;
 
     #[SerializedName('CreationDate')]
     #[Type("DateTime<'Y-m-d\TH:i:s.uT'>")]
@@ -155,12 +151,12 @@ final class PayerProfile
         return $this;
     }
 
-    public function getGender(): ?string
+    public function getGender(): ?Gender
     {
         return $this->gender;
     }
 
-    public function setGender(?string $gender): self
+    public function setGender(?Gender $gender): self
     {
         $this->gender = $gender;
 

--- a/lib/SaferpayJson/Request/Container/PaymentMeans.php
+++ b/lib/SaferpayJson/Request/Container/PaymentMeans.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\Wallet;
 
 final class PaymentMeans
 {
@@ -15,7 +16,7 @@ final class PaymentMeans
     private ?string $displayText = null;
 
     #[SerializedName('Wallet')]
-    private ?string $wallet = null;
+    private ?Wallet $wallet = null;
 
     #[SerializedName('Card')]
     private ?Card $card = null;
@@ -65,12 +66,12 @@ final class PaymentMeans
         return $this;
     }
 
-    public function getWallet(): ?string
+    public function getWallet(): ?Wallet
     {
         return $this->wallet;
     }
 
-    public function setWallet(?string $wallet): self
+    public function setWallet(?Wallet $wallet): self
     {
         $this->wallet = $wallet;
 

--- a/lib/SaferpayJson/Request/Container/RegisterAlias.php
+++ b/lib/SaferpayJson/Request/Container/RegisterAlias.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\AliasIdGenerator;
 
 final class RegisterAlias
 {
-    public const ID_GENERATOR_MANUAL = 'MANUAL';
-    public const ID_GENERATOR_RANDOM = 'RANDOM';
-    public const ID_GENERATOR_RANDOM_UNIQUE = 'RANDOM_UNIQUE';
-
     #[SerializedName('Id')]
     private ?string $id = null;
 
@@ -20,11 +17,11 @@ final class RegisterAlias
 
     public function __construct(
         #[SerializedName('IdGenerator')]
-        private readonly string $idGenerator,
+        private readonly AliasIdGenerator $idGenerator,
     ) {
     }
 
-    public function getIdGenerator(): string
+    public function getIdGenerator(): AliasIdGenerator
     {
         return $this->idGenerator;
     }

--- a/lib/SaferpayJson/Request/Container/RiskFactors.php
+++ b/lib/SaferpayJson/Request/Container/RiskFactors.php
@@ -5,17 +5,12 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\DeliveryType;
 
 final class RiskFactors
 {
-    public const DELIVERY_TYPE_EMAIL = 'EMAIL';
-    public const DELIVERY_TYPE_SHOP = 'SHOP';
-    public const DELIVERY_TYPE_HOMEDELIVERY = 'HOMEDELIVERY';
-    public const DELIVERY_TYPE_PICKUP = 'PICKUP';
-    public const DELIVERY_TYPE_HQ = 'HQ';
-
     #[SerializedName('DeliveryType')]
-    private ?string $deliveryType = null;
+    private ?DeliveryType $deliveryType = null;
 
     #[SerializedName('PayerProfile')]
     private ?PayerProfile $payerProfile = null;
@@ -26,12 +21,12 @@ final class RiskFactors
     #[SerializedName('DeviceFingerprintTransactionId')]
     private ?string $deviceFingerprintTransactionId = null;
 
-    public function getDeliveryType(): ?string
+    public function getDeliveryType(): ?DeliveryType
     {
         return $this->deliveryType;
     }
 
-    public function setDeliveryType(?string $deliveryType): self
+    public function setDeliveryType(?DeliveryType $deliveryType): self
     {
         $this->deliveryType = $deliveryType;
 

--- a/lib/SaferpayJson/Request/Container/SchemeToken.php
+++ b/lib/SaferpayJson/Request/Container/SchemeToken.php
@@ -5,17 +5,10 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\SchemeTokenType;
 
 final class SchemeToken
 {
-    public const TOKEN_TYPE_APPLEPAY = 'APPLEPAY';
-    public const TOKEN_TYPE_GOOGLEPAY = 'GOOGLEPAY';
-    public const TOKEN_TYPE_SAMSUNGPAY = 'SAMSUNGPAY';
-    public const TOKEN_TYPE_CLICKTOPAY = 'CLICKTOPAY';
-    public const TOKEN_TYPE_OTHER = 'OTHER';
-    public const TOKEN_TYPE_MDES = 'MDES';
-    public const TOKEN_TYPE_VTS = 'VTS';
-
     #[SerializedName('Eci')]
     private ?string $eci = null;
 
@@ -29,7 +22,7 @@ final class SchemeToken
         #[SerializedName('AuthValue')]
         private readonly string $authValue,
         #[SerializedName('TokenType')]
-        private readonly string $tokenType,
+        private readonly SchemeTokenType $tokenType,
     ) {
     }
 
@@ -65,7 +58,7 @@ final class SchemeToken
         return $this;
     }
 
-    public function getTokenType(): string
+    public function getTokenType(): SchemeTokenType
     {
         return $this->tokenType;
     }

--- a/lib/SaferpayJson/Request/Container/Styling.php
+++ b/lib/SaferpayJson/Request/Container/Styling.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\StylingTheme;
 
 final class Styling
 {
-    public const THEME_DEFAULT = 'DEFAULT';
-    public const THEME_SIX = 'SIX';
-    public const THEME_NONE = 'NONE';
-
     #[SerializedName('CssUrl')]
     private ?string $cssUrl = null;
 
@@ -19,7 +16,7 @@ final class Styling
     private ?bool $contentSecurityEnabled = null;
 
     #[SerializedName('Theme')]
-    private ?string $theme = null;
+    private ?StylingTheme $theme = null;
 
     public function getCssUrl(): ?string
     {
@@ -49,12 +46,12 @@ final class Styling
         return $this;
     }
 
-    public function getTheme(): ?string
+    public function getTheme(): ?StylingTheme
     {
         return $this->theme;
     }
 
-    public function setTheme(?string $theme): self
+    public function setTheme(?StylingTheme $theme): self
     {
         $this->theme = $theme;
 

--- a/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/PaymentPage/InitializeRequest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\PaymentPage;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\PaymentMethod;
+use Ticketpark\SaferpayJson\Enum\ThreeDsCondition;
+use Ticketpark\SaferpayJson\Enum\Wallet;
 use Ticketpark\SaferpayJson\Request\Container\AddressForm;
 use Ticketpark\SaferpayJson\Request\Container\Authentication;
 use Ticketpark\SaferpayJson\Request\Container\CardForm;
@@ -27,44 +30,10 @@ final class InitializeRequest extends Request
     public const API_PATH = '/Payment/v1/PaymentPage/Initialize';
     public const RESPONSE_CLASS = InitializeResponse::class;
 
-    public const PAYMENT_METHOD_ACCOUNTTOACCOUNT = 'ACCOUNTTOACCOUNT';
-    public const PAYMENT_METHOD_ALIPAY = 'ALIPAY';
-    public const PAYMENT_METHOD_AMEX = 'AMEX';
-    public const PAYMENT_METHOD_BANCONTACT = 'BANCONTACT';
-    public const PAYMENT_METHOD_DINERS = 'DINERS';
-    public const PAYMENT_METHOD_CARD = 'CARD';
-    public const PAYMENT_METHOD_DIRECTDEBIT = 'DIRECTDEBIT';
-    public const PAYMENT_METHOD_EPRZELEWY = 'EPRZELEWY';
-    public const PAYMENT_METHOD_EPS = 'EPS';
-    public const PAYMENT_METHOD_IDEAL = 'IDEAL';
-    public const PAYMENT_METHOD_INVOICE = 'INVOICE';
-    public const PAYMENT_METHOD_JCB = 'JCB';
-    public const PAYMENT_METHOD_KLARNA = 'KLARNA';
-    public const PAYMENT_METHOD_MAESTRO = 'MAESTRO';
-    public const PAYMENT_METHOD_MASTERCARD = 'MASTERCARD';
-    public const PAYMENT_METHOD_PAYCONIQ = 'PAYCONIQ';
-    public const PAYMENT_METHOD_PAYPAL = 'PAYPAL';
-    public const PAYMENT_METHOD_POSTFINANCEPAY = 'POSTFINANCEPAY';
-    public const PAYMENT_METHOD_REKA = 'REKA';
-    public const PAYMENT_METHOD_SAFERPAYTEST = 'SAFERPAYTEST';
-    public const PAYMENT_METHOD_TWINT = 'TWINT';
-    public const PAYMENT_METHOD_UNIONPAY = 'UNIONPAY';
-    public const PAYMENT_METHOD_VISA = 'VISA';
-    public const PAYMENT_METHOD_WERO = 'WERO';
-    public const PAYMENT_METHOD_WECHATPAY = 'WECHATPAY';
-
-    public const WALLET_APPLEPAY = 'APPLEPAY';
-    public const WALLET_GOOGLEPAY = 'GOOGLEPAY';
-    public const WALLET_CLICKTOPAY = 'CLICKTOPAY';
-
-    public const CONDITION_THREE_DS_AUTHENTICATION_SUCCESSFUL_OR_ATTEMPTED = 'THREE_DS_AUTHENTICATION_SUCCESSFUL_OR_ATTEMPTED';
-    public const CONDITION_WITH_SUCCESSFUL_THREE_DS_CHALLENGE = 'WITH_SUCCESSFUL_THREE_DS_CHALLENGE';
-    public const CONDITION_NONE = 'NONE';
-
     #[SerializedName('ConfigSet')]
     private ?string $configSet = null;
 
-    /** @var list<string>|null */
+    /** @var list<PaymentMethod>|null */
     #[SerializedName('PaymentMethods')]
     private ?array $paymentMethods = null;
 
@@ -74,7 +43,7 @@ final class InitializeRequest extends Request
     #[SerializedName('Authentication')]
     private ?Authentication $authentication = null;
 
-    /** @var list<string>|null */
+    /** @var list<Wallet>|null */
     #[SerializedName('Wallets')]
     private ?array $wallets = null;
 
@@ -97,7 +66,7 @@ final class InitializeRequest extends Request
     private ?CardForm $cardForm = null;
 
     #[SerializedName('Condition')]
-    private ?string $condition = null;
+    private ?ThreeDsCondition $condition = null;
 
     #[SerializedName('Order')]
     private ?Order $order = null;
@@ -144,13 +113,13 @@ final class InitializeRequest extends Request
         return $this;
     }
 
-    /** @return list<string>|null */
+    /** @return list<PaymentMethod>|null */
     public function getPaymentMethods(): ?array
     {
         return $this->paymentMethods;
     }
 
-    /** @param list<string>|null $paymentMethods */
+    /** @param list<PaymentMethod>|null $paymentMethods */
     public function setPaymentMethods(?array $paymentMethods): self
     {
         $this->paymentMethods = $paymentMethods;
@@ -182,13 +151,13 @@ final class InitializeRequest extends Request
         return $this;
     }
 
-    /** @return list<string>|null */
+    /** @return list<Wallet>|null */
     public function getWallets(): ?array
     {
         return $this->wallets;
     }
 
-    /** @param list<string>|null $wallets */
+    /** @param list<Wallet>|null $wallets */
     public function setWallets(?array $wallets): self
     {
         $this->wallets = $wallets;
@@ -268,12 +237,12 @@ final class InitializeRequest extends Request
         return $this;
     }
 
-    public function getCondition(): ?string
+    public function getCondition(): ?ThreeDsCondition
     {
         return $this->condition;
     }
 
-    public function setCondition(?string $condition): self
+    public function setCondition(?ThreeDsCondition $condition): self
     {
         $this->condition = $condition;
 

--- a/lib/SaferpayJson/Request/SecureCardData/AliasInsertRequest.php
+++ b/lib/SaferpayJson/Request/SecureCardData/AliasInsertRequest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\SecureCardData;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\AliasInsertType;
+use Ticketpark\SaferpayJson\Enum\PaymentMethod;
 use Ticketpark\SaferpayJson\Request\Container\CardForm;
 use Ticketpark\SaferpayJson\Request\Container\Check;
 use Ticketpark\SaferpayJson\Request\Container\PaymentMeans;
@@ -23,23 +25,6 @@ final class AliasInsertRequest extends Request
     public const API_PATH = '/Payment/v1/Alias/Insert';
     public const RESPONSE_CLASS = AliasInsertResponse::class;
 
-    public const PAYMENT_METHOD_AMEX = 'AMEX';
-    public const PAYMENT_METHOD_DINERS = 'DINERS';
-    public const PAYMENT_METHOD_DIRECTDEBIT = 'DIRECTDEBIT';
-    public const PAYMENT_METHOD_JCB = 'JCB';
-    public const PAYMENT_METHOD_MAESTRO = 'MAESTRO';
-    public const PAYMENT_METHOD_MASTERCARD = 'MASTERCARD';
-    public const PAYMENT_METHOD_POSTFINANCEPAY = 'POSTFINANCEPAY';
-    public const PAYMENT_METHOD_SAFERPAYTEST = 'SAFERPAYTEST';
-    public const PAYMENT_METHOD_VISA = 'VISA';
-    public const PAYMENT_METHOD_WERO = 'WERO';
-    public const PAYMENT_METHOD_WECHATPAY = 'WECHATPAY';
-
-    public const TYPE_CARD = 'CARD';
-    public const TYPE_BANK_ACCOUNT = 'BANK_ACCOUNT';
-    public const TYPE_POSTFINANCE = 'POSTFINANCE';
-    public const TYPE_TWINT = 'TWINT';
-
     #[SerializedName('Styling')]
     private ?Styling $styling = null;
 
@@ -49,7 +34,7 @@ final class AliasInsertRequest extends Request
     #[SerializedName('Check')]
     private ?Check $check = null;
 
-    /** @var list<string>|null */
+    /** @var list<PaymentMethod>|null */
     #[SerializedName('PaymentMethods')]
     private ?array $paymentMethods = null;
 
@@ -67,7 +52,7 @@ final class AliasInsertRequest extends Request
         #[SerializedName('RegisterAlias')]
         private readonly RegisterAlias $registerAlias,
         #[SerializedName('Type')]
-        private readonly string $type,
+        private readonly AliasInsertType $type,
         #[SerializedName('ReturnUrl')]
         private readonly ReturnUrl $returnUrl,
     ) {
@@ -79,7 +64,7 @@ final class AliasInsertRequest extends Request
         return $this->registerAlias;
     }
 
-    public function getType(): string
+    public function getType(): AliasInsertType
     {
         return $this->type;
     }
@@ -125,13 +110,13 @@ final class AliasInsertRequest extends Request
         return $this;
     }
 
-    /** @return list<string>|null */
+    /** @return list<PaymentMethod>|null */
     public function getPaymentMethods(): ?array
     {
         return $this->paymentMethods;
     }
 
-    /** @param list<string>|null $paymentMethods */
+    /** @param list<PaymentMethod>|null $paymentMethods */
     public function setPaymentMethods(?array $paymentMethods): self
     {
         $this->paymentMethods = $paymentMethods;

--- a/lib/SaferpayJson/Request/Transaction/AuthorizeDirectRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/AuthorizeDirectRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Transaction;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\Initiator;
 use Ticketpark\SaferpayJson\Request\Container\Authentication;
 use Ticketpark\SaferpayJson\Request\Container\DccReference;
 use Ticketpark\SaferpayJson\Request\Container\Order;
@@ -23,9 +24,6 @@ final class AuthorizeDirectRequest extends Request
     use RequestCommonsTrait;
     public const API_PATH = '/Payment/v1/Transaction/AuthorizeDirect';
     public const RESPONSE_CLASS = AuthorizeDirectResponse::class;
-
-    public const INITIATOR_MERCHANT = 'MERCHANT';
-    public const INITIATOR_PAYER = 'PAYER';
 
     #[SerializedName('Authentication')]
     private ?Authentication $authentication = null;
@@ -46,7 +44,7 @@ final class AuthorizeDirectRequest extends Request
     private ?RiskFactors $riskFactors = null;
 
     #[SerializedName('Initiator')]
-    private ?string $initiator = null;
+    private ?Initiator $initiator = null;
 
     public function __construct(
         RequestConfig $requestConfig,
@@ -147,12 +145,12 @@ final class AuthorizeDirectRequest extends Request
         return $this;
     }
 
-    public function getInitiator(): ?string
+    public function getInitiator(): ?Initiator
     {
         return $this->initiator;
     }
 
-    public function setInitiator(?string $initiator): self
+    public function setInitiator(?Initiator $initiator): self
     {
         $this->initiator = $initiator;
 

--- a/lib/SaferpayJson/Request/Transaction/AuthorizeRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/AuthorizeRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Transaction;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\ThreeDsCondition;
 use Ticketpark\SaferpayJson\Request\Container\RegisterAlias;
 use Ticketpark\SaferpayJson\Request\Request;
 use Ticketpark\SaferpayJson\Request\RequestCommonsTrait;
@@ -17,12 +18,8 @@ final class AuthorizeRequest extends Request
     public const API_PATH = '/Payment/v1/Transaction/Authorize';
     public const RESPONSE_CLASS = AuthorizeResponse::class;
 
-    public const CONDITION_THREE_DS_AUTHENTICATION_SUCCESSFUL_OR_ATTEMPTED = 'THREE_DS_AUTHENTICATION_SUCCESSFUL_OR_ATTEMPTED';
-    public const CONDITION_WITH_SUCCESSFUL_THREE_DS_CHALLENGE = 'WITH_SUCCESSFUL_THREE_DS_CHALLENGE';
-    public const CONDITION_NONE = 'NONE';
-
     #[SerializedName('Condition')]
-    private ?string $condition = null;
+    private ?ThreeDsCondition $condition = null;
 
     #[SerializedName('VerificationCode')]
     private ?string $verificationCode = null;
@@ -43,7 +40,7 @@ final class AuthorizeRequest extends Request
         return $this->token;
     }
 
-    public function getCondition(): ?string
+    public function getCondition(): ?ThreeDsCondition
     {
         return $this->condition;
     }
@@ -58,7 +55,7 @@ final class AuthorizeRequest extends Request
         return $this->registerAlias;
     }
 
-    public function setCondition(?string $condition): self
+    public function setCondition(?ThreeDsCondition $condition): self
     {
         $this->condition = $condition;
 

--- a/lib/SaferpayJson/Request/Transaction/InitializeRequest.php
+++ b/lib/SaferpayJson/Request/Transaction/InitializeRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Request\Transaction;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\PaymentMethod;
 use Ticketpark\SaferpayJson\Request\Container\Authentication;
 use Ticketpark\SaferpayJson\Request\Container\CardForm;
 use Ticketpark\SaferpayJson\Request\Container\Order;
@@ -27,20 +28,6 @@ final class InitializeRequest extends Request
     public const API_PATH = '/Payment/v1/Transaction/Initialize';
     public const RESPONSE_CLASS = InitializeResponse::class;
 
-    public const PAYMENT_METHOD_AMEX = 'AMEX';
-    public const PAYMENT_METHOD_BANCONTACT = 'BANCONTACT';
-    public const PAYMENT_METHOD_DINERS = 'DINERS';
-    public const PAYMENT_METHOD_DIRECTDEBIT = 'DIRECTDEBIT';
-    public const PAYMENT_METHOD_JCB = 'JCB';
-    public const PAYMENT_METHOD_MAESTRO = 'MAESTRO';
-    public const PAYMENT_METHOD_MASTERCARD = 'MASTERCARD';
-    public const PAYMENT_METHOD_REKA = 'REKA';
-    public const PAYMENT_METHOD_VISA = 'VISA';
-    public const PAYMENT_METHOD_WERO = 'WERO';
-    public const PAYMENT_METHOD_WECHATPAY = 'WECHATPAY';
-
-    public const WALLET_MASTERPASS = 'MASTERPASS';
-
     #[SerializedName('ConfigSet')]
     private ?string $configSet = null;
 
@@ -56,7 +43,7 @@ final class InitializeRequest extends Request
     #[SerializedName('Styling')]
     private ?Styling $styling = null;
 
-    /** @var list<string>|null */
+    /** @var list<PaymentMethod>|null */
     #[SerializedName('PaymentMethods')]
     private ?array $paymentMethods = null;
 
@@ -130,7 +117,7 @@ final class InitializeRequest extends Request
         return $this;
     }
 
-    /** @param list<string>|null $paymentMethods */
+    /** @param list<PaymentMethod>|null $paymentMethods */
     public function setPaymentMethods(?array $paymentMethods): self
     {
         $this->paymentMethods = $paymentMethods;
@@ -206,7 +193,7 @@ final class InitializeRequest extends Request
         return $this->styling;
     }
 
-    /** @return list<string>|null */
+    /** @return list<PaymentMethod>|null */
     public function getPaymentMethods(): ?array
     {
         return $this->paymentMethods;

--- a/lib/SaferpayJson/Response/Container/Address.php
+++ b/lib/SaferpayJson/Response/Container/Address.php
@@ -6,6 +6,7 @@ namespace Ticketpark\SaferpayJson\Response\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Type;
+use Ticketpark\SaferpayJson\Enum\Gender;
 
 final class Address
 {
@@ -19,7 +20,7 @@ final class Address
     private ?string $company = null;
 
     #[SerializedName('Gender')]
-    private ?string $gender = null;
+    private ?Gender $gender = null;
 
     #[SerializedName('Street')]
     private ?string $street = null;
@@ -67,7 +68,7 @@ final class Address
         return $this->company;
     }
 
-    public function getGender(): ?string
+    public function getGender(): ?Gender
     {
         return $this->gender;
     }

--- a/lib/SaferpayJson/Response/Container/Address.php
+++ b/lib/SaferpayJson/Response/Container/Address.php
@@ -9,11 +9,6 @@ use JMS\Serializer\Annotation\Type;
 
 final class Address
 {
-    public const GENDER_MALE = 'MALE';
-    public const GENDER_FEMALE = 'FEMALE';
-    public const GENDER_DIVERSE = 'DIVERSE';
-    public const GENDER_COMPANY = 'COMPANY';
-
     #[SerializedName('FirstName')]
     private ?string $firstName = null;
 

--- a/lib/SaferpayJson/Response/Container/Brand.php
+++ b/lib/SaferpayJson/Response/Container/Brand.php
@@ -8,30 +8,6 @@ use JMS\Serializer\Annotation\SerializedName;
 
 final class Brand
 {
-    public const PAYMENT_METHOD_ALIPAY = 'ALIPAY';
-    public const PAYMENT_METHOD_AMEX = 'AMEX';
-    public const PAYMENT_METHOD_BANCONTACT = 'BANCONTACT';
-    public const PAYMENT_METHOD_DINERS = 'DINERS';
-    public const PAYMENT_METHOD_DIRECTDEBIT = 'DIRECTDEBIT';
-    public const PAYMENT_METHOD_EPRZELEWY = 'EPRZELEWY';
-    public const PAYMENT_METHOD_EPS = 'EPS';
-    public const PAYMENT_METHOD_IDEAL = 'IDEAL';
-    public const PAYMENT_METHOD_INVOICE = 'INVOICE';
-    public const PAYMENT_METHOD_JCB = 'JCB';
-    public const PAYMENT_METHOD_KLARNA = 'KLARNA';
-    public const PAYMENT_METHOD_MAESTRO = 'MAESTRO';
-    public const PAYMENT_METHOD_MASTERCARD = 'MASTERCARD';
-    public const PAYMENT_METHOD_PAYPAL = 'PAYPAL';
-    public const PAYMENT_METHOD_POSTCARD = 'POSTCARD';
-    public const PAYMENT_METHOD_POSTFINANCE = 'POSTFINANCE';
-    public const PAYMENT_METHOD_REKA = 'REKA';
-    public const PAYMENT_METHOD_TWINT = 'TWINT';
-    public const PAYMENT_METHOD_UNIONPAY = 'UNIONPAY';
-    public const PAYMENT_METHOD_VISA = 'VISA';
-    public const PAYMENT_METHOD_VPAY = 'VPAY';
-    public const PAYMENT_METHOD_WERO = 'WERO';
-    public const PAYMENT_METHOD_WECHATPAY = 'WECHATPAY';
-
     #[SerializedName('PaymentMethod')]
     private ?string $paymentMethod = null;
 

--- a/lib/SaferpayJson/Response/Container/Brand.php
+++ b/lib/SaferpayJson/Response/Container/Brand.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Response\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\PaymentMethod;
 
 final class Brand
 {
     #[SerializedName('PaymentMethod')]
-    private ?string $paymentMethod = null;
+    private ?PaymentMethod $paymentMethod = null;
 
     #[SerializedName('Name')]
     private ?string $name = null;
 
-    public function getPaymentMethod(): ?string
+    public function getPaymentMethod(): ?PaymentMethod
     {
         return $this->paymentMethod;
     }

--- a/lib/SaferpayJson/Response/Container/PaymentMeans.php
+++ b/lib/SaferpayJson/Response/Container/PaymentMeans.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ticketpark\SaferpayJson\Response\Container;
 
 use JMS\Serializer\Annotation\SerializedName;
+use Ticketpark\SaferpayJson\Enum\Wallet;
 
 final class PaymentMeans
 {
@@ -15,7 +16,7 @@ final class PaymentMeans
     private ?string $displayText = null;
 
     #[SerializedName('Wallet')]
-    private ?string $wallet = null;
+    private ?Wallet $wallet = null;
 
     #[SerializedName('Card')]
     private ?Card $card = null;
@@ -36,7 +37,7 @@ final class PaymentMeans
         return $this->displayText;
     }
 
-    public function getWallet(): ?string
+    public function getWallet(): ?Wallet
     {
         return $this->wallet;
     }

--- a/tests/SaferpayJson/Tests/Request/SecureCardData/AliasInsertDirectRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/SecureCardData/AliasInsertDirectRequestTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ticketpark\SaferpayJson\Tests\Request\SecureCardData;
 
+use Ticketpark\SaferpayJson\Enum\AliasIdGenerator;
 use Ticketpark\SaferpayJson\Request\Container\PaymentMeans;
 use Ticketpark\SaferpayJson\Request\Container\RegisterAlias;
 use Ticketpark\SaferpayJson\Request\SecureCardData\AliasInsertDirectRequest;
@@ -15,7 +16,7 @@ class AliasInsertDirectRequestTest extends CommonRequestTestCase
     {
         return new AliasInsertDirectRequest(
             $this->getRequestConfig(),
-            new RegisterAlias(RegisterAlias::ID_GENERATOR_RANDOM),
+            new RegisterAlias(AliasIdGenerator::Random),
             new PaymentMeans(),
         );
     }

--- a/tests/SaferpayJson/Tests/Request/SecureCardData/AliasInsertRequestTest.php
+++ b/tests/SaferpayJson/Tests/Request/SecureCardData/AliasInsertRequestTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ticketpark\SaferpayJson\Tests\Request\SecureCardData;
 
+use Ticketpark\SaferpayJson\Enum\AliasIdGenerator;
+use Ticketpark\SaferpayJson\Enum\AliasInsertType;
 use Ticketpark\SaferpayJson\Request\Container\RegisterAlias;
 use Ticketpark\SaferpayJson\Request\Container\ReturnUrl;
 use Ticketpark\SaferpayJson\Request\SecureCardData\AliasInsertRequest;
@@ -23,8 +25,8 @@ class AliasInsertRequestTest extends CommonRequestTestCase
     {
         return new AliasInsertRequest(
             $this->getRequestConfig(),
-            new RegisterAlias(RegisterAlias::ID_GENERATOR_RANDOM),
-            AliasInsertRequest::TYPE_CARD,
+            new RegisterAlias(AliasIdGenerator::Random),
+            AliasInsertType::Card,
             new ReturnUrl('success-url'),
         );
     }


### PR DESCRIPTION
- Add `Ticketpark\SaferpayJson\Enum` with backed enums for shared API vocabulary (payment methods, wallets, 3DS conditions, alias types, address form fields, and more)
- Wire enums into request containers and request classes with typed properties, constructors, and setters
- Remove duplicated `public const` definitions from request classes and `Brand`
- Update tests and examples to use enums (e.g. `PaymentMethod::Visa`, `AliasIdGenerator::Random`, `AliasInsertType::Card`)

Made with [Cursor](https://cursor.com)